### PR TITLE
feat: upgrade to xdg-effect 0.2.0

### DIFF
--- a/package/__test__/cli/commands.int.test.ts
+++ b/package/__test__/cli/commands.int.test.ts
@@ -6,7 +6,7 @@ import { Command } from "@effect/cli";
 import { NodeContext } from "@effect/platform-node";
 import { ConfigProvider, Effect, Layer, Option } from "effect";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { AppDirsConfig, ExplicitPath, FirstMatch, TomlCodec, XdgConfigLive, makeConfigFileLive } from "xdg-effect";
+import { AppDirsConfig, ConfigFile, ExplicitPath, FirstMatch, TomlCodec, XdgConfigLive } from "xdg-effect";
 import { credentialsCommand } from "../../src/cli/commands/credentials.js";
 import { doctorCommand } from "../../src/cli/commands/doctor.js";
 import { initCommand } from "../../src/cli/commands/init.js";
@@ -194,7 +194,7 @@ function makeTestConfigLayer(configPath: string) {
 }
 
 function makeTestCredentialsLayer(credentialsPath: string, configLayer: ReturnType<typeof makeTestConfigLayer>) {
-	return makeConfigFileLive({
+	return ConfigFile.Live({
 		tag: RepoSyncCredentialsFile,
 		schema: CredentialsSchema,
 		codec: TomlCodec,
@@ -235,13 +235,15 @@ function makeAppDirsLayer(configDir: string) {
  * Used for credentials command tests that need the credentials service.
  */
 function makeAppDirsWithCredsLayer(configDir: string) {
+	const credsPath = join(configDir, "repo-sync.credentials.toml");
 	const base = makeAppDirsLayer(configDir);
-	const credsLayer = makeConfigFileLive({
+	const credsLayer = ConfigFile.Live({
 		tag: RepoSyncCredentialsFile,
 		schema: CredentialsSchema,
 		codec: TomlCodec,
 		strategy: FirstMatch,
-		resolvers: [ExplicitPath(join(configDir, "repo-sync.credentials.toml"))],
+		resolvers: [ExplicitPath(credsPath)],
+		defaultPath: Effect.succeed(credsPath),
 	}).pipe(Layer.provide(base));
 	return Layer.mergeAll(base, credsLayer);
 }

--- a/package/__test__/services/ConfigFiles.int.test.ts
+++ b/package/__test__/services/ConfigFiles.int.test.ts
@@ -7,16 +7,7 @@ import { NodeFileSystem } from "@effect/platform-node";
 import { ConfigProvider, Effect, Layer, Option } from "effect";
 import { describe, expect, it } from "vitest";
 import type { ConfigError } from "xdg-effect";
-import {
-	AppDirs,
-	AppDirsConfig,
-	ExplicitPath,
-	FirstMatch,
-	TomlCodec,
-	XdgConfigLive,
-	makeConfigFileLive,
-	makeConfigFileTag,
-} from "xdg-effect";
+import { AppDirs, AppDirsConfig, ConfigFile, ExplicitPath, FirstMatch, TomlCodec, XdgConfigLive } from "xdg-effect";
 import type { Config } from "../../src/schemas/config.js";
 import { ConfigSchema } from "../../src/schemas/config.js";
 import type { Credentials } from "../../src/schemas/credentials.js";
@@ -35,8 +26,8 @@ function fixtureContent(name: string): string {
 }
 
 // Tags for test-scoped config file services
-const TestConfigFile = makeConfigFileTag<Config>("test/Config");
-const TestCredentialsFile = makeConfigFileTag<Credentials>("test/Credentials");
+const TestConfigFile = ConfigFile.Tag<Config>("test/Config");
+const TestCredentialsFile = ConfigFile.Tag<Credentials>("test/Credentials");
 
 /**
  * Build a config layer with ExplicitPath resolver pointing at a known file.
@@ -44,7 +35,7 @@ const TestCredentialsFile = makeConfigFileTag<Credentials>("test/Credentials");
  */
 function makeConfigLayer(configPath: string) {
 	return XdgConfigLive({
-		app: new AppDirsConfig({ namespace: "repo-sync", fallbackDir: Option.none(), dirs: Option.none() }),
+		app: new AppDirsConfig({ namespace: "repo-sync" }),
 		config: {
 			tag: TestConfigFile,
 			schema: ConfigSchema,
@@ -56,7 +47,7 @@ function makeConfigLayer(configPath: string) {
 }
 
 function makeCredentialsLayer(credentialsPath: string, configLayer: ReturnType<typeof makeConfigLayer>) {
-	return makeConfigFileLive({
+	return ConfigFile.Live({
 		tag: TestCredentialsFile,
 		schema: CredentialsSchema,
 		codec: TomlCodec,
@@ -424,7 +415,7 @@ describe("ConfigFiles filesystem integration", () => {
 		);
 
 		const layer = XdgConfigLive({
-			app: new AppDirsConfig({ namespace: "repo-sync", fallbackDir: Option.none(), dirs: Option.none() }),
+			app: new AppDirsConfig({ namespace: "repo-sync" }),
 			config: {
 				tag: TestConfigFile,
 				schema: ConfigSchema,
@@ -448,7 +439,7 @@ describe("ConfigFiles filesystem integration", () => {
 		const provider = ConfigProvider.fromMap(new Map([["HOME", "/test/home"]]));
 
 		const layer = XdgConfigLive({
-			app: new AppDirsConfig({ namespace: "repo-sync", fallbackDir: Option.none(), dirs: Option.none() }),
+			app: new AppDirsConfig({ namespace: "repo-sync" }),
 			config: {
 				tag: TestConfigFile,
 				schema: ConfigSchema,

--- a/package/lib/scripts/generate-json-schema.ts
+++ b/package/lib/scripts/generate-json-schema.ts
@@ -2,7 +2,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NodeFileSystem } from "@effect/platform-node";
 import { Effect } from "effect";
-import { JsonSchemaExporter, JsonSchemaExporterLive } from "xdg-effect";
+import { JsonSchemaExporter } from "xdg-effect";
 import { ConfigSchema } from "../../src/schemas/config.js";
 import { CredentialsSchema } from "../../src/schemas/credentials.js";
 
@@ -47,4 +47,4 @@ const program = Effect.gen(function* () {
 	}
 });
 
-Effect.runPromise(program.pipe(Effect.provide(JsonSchemaExporterLive), Effect.provide(NodeFileSystem.layer)));
+Effect.runPromise(program.pipe(Effect.provide(JsonSchemaExporter.Live), Effect.provide(NodeFileSystem.layer)));

--- a/package/package.json
+++ b/package/package.json
@@ -58,7 +58,7 @@
 		"effect": "^3.21.1",
 		"smol-toml": ">=1.6.1",
 		"tweetnacl": "^1.0.3",
-		"xdg-effect": "^0.1.0"
+		"xdg-effect": "^0.2.0"
 	},
 	"devDependencies": {
 		"@savvy-web/rslib-builder": "^0.20.1",

--- a/package/src/cli/commands/credentials.ts
+++ b/package/src/cli/commands/credentials.ts
@@ -1,12 +1,10 @@
-import { existsSync, mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { Command, Options } from "@effect/cli";
 import { Console, Effect } from "effect";
 import { AppDirs } from "xdg-effect";
 import type { Credentials } from "../../schemas/credentials.js";
 import { RepoSyncCredentialsFile } from "../../services/ConfigFiles.js";
 
-const CREDENTIALS_FILENAME = "repo-sync.credentials.toml";
+const EMPTY_CREDENTIALS: Credentials = { profiles: {} };
 
 const profileOption = Options.text("profile").pipe(Options.withDescription("Credential profile name"));
 
@@ -20,10 +18,6 @@ const opTokenOption = Options.text("op-token").pipe(
 	Options.optional,
 );
 
-function loadCredentials(credentialsFile: Effect.Effect.Success<typeof RepoSyncCredentialsFile>) {
-	return credentialsFile.load.pipe(Effect.orElseSucceed((): Credentials => ({ profiles: {} })));
-}
-
 function redactToken(token: string): string {
 	if (token.length <= 8) return "****";
 	return `${token.slice(0, 4)}...${token.slice(-4)}`;
@@ -35,13 +29,10 @@ const createCommand = Command.make(
 	({ profile, githubToken, opToken }) =>
 		Effect.gen(function* () {
 			const appDirs = yield* AppDirs;
-			const configDir = yield* appDirs.config;
-			if (!existsSync(configDir)) {
-				mkdirSync(configDir, { recursive: true });
-			}
+			yield* appDirs.ensureConfig;
 
 			const credentialsFile = yield* RepoSyncCredentialsFile;
-			const creds = yield* loadCredentials(credentialsFile);
+			const creds = yield* credentialsFile.loadOrDefault(EMPTY_CREDENTIALS);
 
 			if (creds.profiles[profile]) {
 				yield* Console.error(`Profile '${profile}' already exists. Delete it first.`);
@@ -61,13 +52,15 @@ const createCommand = Command.make(
 				return;
 			}
 
-			const updatedCreds: Credentials = {
-				profiles: {
-					...creds.profiles,
-					[profile]: { github_token: newProfile.github_token ?? "", ...newProfile },
-				},
-			};
-			yield* credentialsFile.write(updatedCreds, join(configDir, CREDENTIALS_FILENAME));
+			yield* credentialsFile.update(
+				(current) => ({
+					profiles: {
+						...current.profiles,
+						[profile]: { github_token: newProfile.github_token ?? "", ...newProfile },
+					},
+				}),
+				EMPTY_CREDENTIALS,
+			);
 
 			yield* Console.log(`Created profile '${profile}'.`);
 		}),
@@ -76,7 +69,7 @@ const createCommand = Command.make(
 const listCredsCommand = Command.make("list", {}, () =>
 	Effect.gen(function* () {
 		const credentialsFile = yield* RepoSyncCredentialsFile;
-		const creds = yield* loadCredentials(credentialsFile);
+		const creds = yield* credentialsFile.loadOrDefault(EMPTY_CREDENTIALS);
 
 		if (Object.keys(creds.profiles).length === 0) {
 			yield* Console.log("No credential profiles configured.");
@@ -99,8 +92,10 @@ const listCredsCommand = Command.make("list", {}, () =>
 const deleteCommand = Command.make("delete", { profile: profileOption }, ({ profile }) =>
 	Effect.gen(function* () {
 		const appDirs = yield* AppDirs;
+		yield* appDirs.ensureConfig;
+
 		const credentialsFile = yield* RepoSyncCredentialsFile;
-		const creds = yield* loadCredentials(credentialsFile);
+		const creds = yield* credentialsFile.loadOrDefault(EMPTY_CREDENTIALS);
 
 		if (!creds.profiles[profile]) {
 			yield* Console.error(`Profile '${profile}' not found.`);
@@ -108,12 +103,7 @@ const deleteCommand = Command.make("delete", { profile: profileOption }, ({ prof
 		}
 
 		const { [profile]: _, ...remainingProfiles } = creds.profiles;
-		const updatedCreds: Credentials = { profiles: remainingProfiles };
-		const configDir = yield* appDirs.config;
-		if (!existsSync(configDir)) {
-			mkdirSync(configDir, { recursive: true });
-		}
-		yield* credentialsFile.write(updatedCreds, join(configDir, CREDENTIALS_FILENAME));
+		yield* credentialsFile.save({ profiles: remainingProfiles });
 
 		yield* Console.log(`Deleted profile '${profile}'.`);
 	}),

--- a/package/src/cli/commands/sync.ts
+++ b/package/src/cli/commands/sync.ts
@@ -51,11 +51,7 @@ export const syncCommand = Command.make(
 			const { config: parsedConfig, configDir } = yield* loadConfigWithDir(configFile, config);
 
 			const credentialsFile = yield* RepoSyncCredentialsFile;
-			const credsResult = yield* Effect.either(credentialsFile.load);
-			const credentials =
-				credsResult._tag === "Right"
-					? credsResult.right
-					: { profiles: {} as Record<string, { github_token: string; op_service_account_token?: string }> };
+			const credentials = yield* credentialsFile.loadOrDefault({ profiles: {} });
 
 			const profileNames = Object.keys(credentials.profiles);
 			const defaultProfile = profileNames.length === 1 ? profileNames[0] : undefined;

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -9,7 +9,7 @@
 
 /* v8 ignore start -- barrel re-exports */
 // Services
-export { AppDirs, ConfigError as XdgConfigError } from "xdg-effect";
+export { AppDirs, ConfigError as XdgConfigError, ConfigFile } from "xdg-effect";
 // Errors
 export { GitHubApiError, OnePasswordError, ResolveError, SyncError } from "./errors.js";
 // Utilities

--- a/package/src/services/ConfigFiles.ts
+++ b/package/src/services/ConfigFiles.ts
@@ -4,14 +4,14 @@ import { Effect, Layer, Option } from "effect";
 import type { ConfigFileService, ConfigSource } from "xdg-effect";
 import {
 	AppDirsConfig,
+	ConfigFile,
 	FirstMatch,
 	TomlCodec,
 	UpwardWalk,
 	XdgConfig,
 	ConfigError as XdgConfigError,
 	XdgConfigLive,
-	makeConfigFileLive,
-	makeConfigFileTag,
+	XdgSavePath,
 } from "xdg-effect";
 import type { Config } from "../schemas/config.js";
 import { ConfigSchema } from "../schemas/config.js";
@@ -21,12 +21,12 @@ import { CredentialsSchema } from "../schemas/credentials.js";
 const CONFIG_FILENAME = "repo-sync.config.toml";
 const CREDENTIALS_FILENAME = "repo-sync.credentials.toml";
 
-export const RepoSyncConfigFile = makeConfigFileTag<Config>("repo-sync/Config");
+export const RepoSyncConfigFile = ConfigFile.Tag<Config>("repo-sync/Config");
 
-export const RepoSyncCredentialsFile = makeConfigFileTag<Credentials>("repo-sync/Credentials");
+export const RepoSyncCredentialsFile = ConfigFile.Tag<Credentials>("repo-sync/Credentials");
 
 const xdgLayer = XdgConfigLive({
-	app: new AppDirsConfig({ namespace: "repo-sync", fallbackDir: Option.none(), dirs: Option.none() }),
+	app: new AppDirsConfig({ namespace: "repo-sync" }),
 	config: {
 		tag: RepoSyncConfigFile,
 		schema: ConfigSchema,
@@ -36,12 +36,13 @@ const xdgLayer = XdgConfigLive({
 	},
 });
 
-const credentialsLayer = makeConfigFileLive({
+const credentialsLayer = ConfigFile.Live({
 	tag: RepoSyncCredentialsFile,
 	schema: CredentialsSchema,
 	codec: TomlCodec,
 	strategy: FirstMatch,
 	resolvers: [UpwardWalk({ filename: CREDENTIALS_FILENAME }), XdgConfig({ filename: CREDENTIALS_FILENAME })],
+	defaultPath: XdgSavePath(CREDENTIALS_FILENAME),
 }).pipe(Layer.provide(xdgLayer));
 
 export const ConfigFilesLive = Layer.mergeAll(xdgLayer, credentialsLayer);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       xdg-effect:
-        specifier: ^0.1.0
-        version: 0.1.0(03f80dd67552833d8eca5052e274b981)
+        specifier: ^0.2.0
+        version: 0.2.0(03f80dd67552833d8eca5052e274b981)
     devDependencies:
       '@savvy-web/rslib-builder':
         specifier: ^0.20.1
@@ -2291,8 +2291,8 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  eventsource-parser@3.0.7:
-    resolution: {integrity: sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -2911,6 +2911,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -4289,8 +4292,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xdg-effect@0.1.0:
-    resolution: {integrity: sha512-NWGq0bLHac5HYcxqHvChW/RnEs6EWIgpHC8BS5nZkvCSrCPyo265QAB0bXx3stTnvLsIVRW2dMmKiGOSDTd03A==}
+  xdg-effect@0.2.0:
+    resolution: {integrity: sha512-fUWxvUvfYIbWc1lU45bhkAm/vHuik+ymlA2phbuL5/re+R+lrOt9ZJrqZHi6mYGIhJNfmGBhEhPSiB5a7glcPw==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       '@effect/platform-node': '>=0.106.0'
@@ -5037,7 +5040,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.7
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
       hono: 4.12.14
@@ -6734,11 +6737,11 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  eventsource-parser@3.0.7: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.7
+      eventsource-parser: 3.0.8
 
   execa@9.6.1:
     dependencies:
@@ -6937,7 +6940,7 @@ snapshots:
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
@@ -7365,6 +7368,12 @@ snapshots:
       graceful-fs: 4.2.11
 
   jsonfile@6.2.0:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -8934,7 +8943,7 @@ snapshots:
 
   ws@8.20.0: {}
 
-  xdg-effect@0.1.0(03f80dd67552833d8eca5052e274b981):
+  xdg-effect@0.2.0(03f80dd67552833d8eca5052e274b981):
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.1)
       effect: 3.21.1


### PR DESCRIPTION
## Summary

- Upgrade xdg-effect from 0.1.0 to 0.2.0
- Adopt new APIs: `ConfigFile.Tag`/`ConfigFile.Live`, `AppDirs.ensureConfig`, `configFile.loadOrDefault`, `configFile.save`, `configFile.update`, `XdgSavePath`, simplified `AppDirsConfig` constructor
- Credentials command now uses `update`/`save`/`loadOrDefault` instead of manual TOML I/O and `mkdirSync` guards
- Sync command uses `loadOrDefault` for optional credentials
- JSON schema script uses `JsonSchemaExporter.Live` getter

Closes #8

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (235 tests)
- [x] `pnpm run build` succeeds
- [x] `pnpm --filter repo-sync generate:json-schema` produces unchanged output

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>