### PR TITLE
feat(schemas): add SchemaStore compatibility and TOML LSP support

### DIFF
--- a/.changeset/bright-schemas.md
+++ b/.changeset/bright-schemas.md
@@ -1,0 +1,30 @@
+---
+"reposets": minor
+---
+
+## Features
+
+### SchemaStore Compatibility
+
+JSON Schemas now include `$id` fields pointing to SchemaStore URLs and pass Ajv strict-mode validation, ready for submission to the JSON Schema Store for automatic editor detection.
+
+* Config schema: `https://json.schemastore.org/reposets.config.json`
+* Credentials schema: `https://json.schemastore.org/reposets.credentials.json`
+
+### TOML Language Server Support
+
+Added typed annotations for both major TOML language servers:
+
+* Taplo: `x-taplo` annotations with `initKeys` for autocompletion scaffolding and `links.key` for documentation URLs
+* Tombi: migrated all `x-tombi-*` annotations to typed `tombi()` helper calls
+
+### Cleaner Schema Output
+
+* Replaced `Schema.Unknown` with `Jsonifiable` from xdg-effect, eliminating `$id: /schemas/unknown` artifacts
+* Empty `required: []` arrays and `properties: {}` on Record types removed by xdg-effect cleanup pass
+
+## Maintenance
+
+* Upgraded xdg-effect from v0.2.0 to v0.3.1
+* Added ajv as a devDependency for strict schema validation
+* Improved schema annotation descriptions and titles across all definitions

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -3,7 +3,7 @@ module: reposets
 title: Architecture
 status: current
 completeness: 95
-last-synced: 2026-04-20
+last-synced: 2026-04-22
 ---
 
 ## Overview
@@ -86,10 +86,11 @@ All errors are `Data.TaggedError` subclasses:
 Each service has Live and Test layer implementations:
 
 - `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 16 service methods including environment operations)
+  all 20 service methods including environment operations)
 - `OnePasswordClientTest(stubs)` - returns deterministic values
 - `ConfigLoaderLive` - used directly in tests (pure parsing, no I/O)
 - `CredentialResolverLive` - tested with real filesystem + mock OP client
 - `SyncLoggerLive` - tested with Ref-based output capture
 
-186 unit tests cover schemas, services, and utilities.
+235 tests (unit + integration) cover schemas, services, CLI commands,
+and utilities.

--- a/.claude/design/reposets/cli.md
+++ b/.claude/design/reposets/cli.md
@@ -3,7 +3,7 @@ module: reposets
 title: CLI Commands
 status: current
 completeness: 95
-last-synced: 2026-04-20
+last-synced: 2026-04-22
 ---
 
 ## Entry Point

--- a/.claude/design/reposets/config-format.md
+++ b/.claude/design/reposets/config-format.md
@@ -3,7 +3,7 @@ module: reposets
 title: Configuration Format
 status: current
 completeness: 95
-last-synced: 2026-04-20
+last-synced: 2026-04-22
 ---
 
 ## Files
@@ -273,14 +273,53 @@ labels referenced by config templates.
 
 ## JSON Schema Generation
 
-Effect Schema definitions generate JSON schemas via `JSONSchema.make()`.
-The generation script (`package/lib/scripts/generate-json-schema.ts`):
+Effect Schema definitions generate JSON schemas via `JsonSchemaExporter`
+from xdg-effect (v0.3.1). The generation script
+(`package/lib/scripts/generate-json-schema.ts`):
 
-1. Generates schemas from Effect Schema definitions
-2. Inlines the root `$ref` so Tombi can read root-level properties
-3. Adds `x-tombi-toml-version` at the root
-4. Outputs to `package/schemas/`
+1. Calls `JsonSchemaExporter.generateMany()` with schema definitions,
+   root def names, and SchemaStore `$id` URLs
+2. Runs Ajv strict-mode validation on the generated schemas with all
+   custom extension keywords registered (`x-tombi-*`, `x-taplo`)
+3. Writes output via `JsonSchemaExporter.writeMany()` to
+   `package/schemas/` (only writes when content changed)
 
-Tombi annotations are defined inline on schemas via `jsonSchema: { ... }`
-annotation property. Standard annotations (title, description, examples,
-default) are also set on all fields.
+SchemaStore `$id` values:
+
+- Config: `https://json.schemastore.org/reposets.config.json`
+- Credentials: `https://json.schemastore.org/reposets.credentials.json`
+
+### Schema Annotations
+
+Schemas use two typed annotation helpers from xdg-effect:
+
+- `tombi({ ... })` -- generates `x-tombi-*` annotations for Tombi TOML
+  LSP: `additionalKeyLabel`, `tableKeysOrder`, `arrayValuesOrder`,
+  `arrayValuesOrderBy`, `stringFormats`, `tomlVersion`
+- `taplo({ ... })` -- generates `x-taplo` annotations for Taplo TOML
+  LSP: `initKeys` (scaffolding hints) and `links.key` (documentation
+  URLs)
+
+Both helpers are applied via the `jsonSchema: { ... }` annotation
+property. When a schema needs both, the results are spread together:
+`jsonSchema: { ...tombi({ ... }), ...taplo({ ... }) }`.
+
+Standard annotations (`title`, `description`, `examples`, `default`)
+are set directly on all fields.
+
+### Jsonifiable Type
+
+Schema fields that accept arbitrary JSON-compatible values (settings
+pass-through, inline credential values) use the `Jsonifiable` schema
+from xdg-effect instead of `Schema.Unknown`. This ensures generated
+JSON schemas produce `{}` instead of `{ "$id": "/schemas/unknown" }`
+for those positions. Three files use `Jsonifiable`: `common.ts`
+(resource value kind), `credentials.ts` (resolve value entries), and
+`config.ts` (settings group index signature).
+
+### Dependencies
+
+- `xdg-effect` (^0.3.1) -- `JsonSchemaExporter`, `Jsonifiable`,
+  `tombi()`, `taplo()` helpers
+- `ajv` (^8.18.0, devDependency) -- strict-mode schema validation
+  during generation

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -3,7 +3,7 @@ module: reposets
 title: Effect Services
 status: current
 completeness: 95
-last-synced: 2026-04-20
+last-synced: 2026-04-22
 ---
 
 ## ConfigLoader
@@ -71,12 +71,13 @@ for test capture. Test layer uses `logLevel: "silent"` to suppress output.
 
 ## GitHubClient
 
-Wraps Octokit with typed methods for all GitHub API operations. 16 methods
+Wraps Octokit with typed methods for all GitHub API operations. 20 methods
 organized into four domains: repo-level resources, environments, and
 environment-scoped resources.
 
 ### Repo-Level Methods
 
+- `getOwnerType(owner)` - determine if owner is a User or Organization
 - `syncSecret(owner, repo, name, value, scope)` - encrypt and upsert
   (actions/dependabot/codespaces)
 - `syncVariable(owner, repo, name, value)` - create or update
@@ -126,7 +127,7 @@ appropriate Octokit API namespace. The `SecretScope` type is
 
 Live: `GitHubClientLive(token)` creates an Octokit instance per token.
 Test: `GitHubClientTest()` returns `{ layer, calls() }` recorder covering
-all 16 methods.
+all 20 methods.
 
 ## SyncEngine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ pnpm run typecheck         # Type-check all workspaces via Turbo
 pnpm sync                  # Alias: tsx package/src/cli/index.ts
 
 # Testing
-pnpm run test              # Run all tests (186 passing)
+pnpm run test              # Run all tests (235 passing)
 pnpm run test:watch        # Run tests in watch mode
 pnpm run test:coverage     # Run tests with coverage report
 
@@ -51,7 +51,7 @@ at `package/` (workspace name: `reposets`).
 ```text
 package/                   # reposets CLI package
 package/src/cli/           # CLI entrypoint and commands
-package/src/services/      # Effect services (6 services, 19 GitHubClient methods)
+package/src/services/      # Effect services (6 services, 20 GitHubClient methods)
 package/src/schemas/       # Effect Schema definitions (config, credentials, environment, ruleset) + JSON schema generation
 package/src/lib/           # Utilities (XDG paths, config resolution, crypto)
 package/__test__/          # Tests mirroring src/ structure
@@ -115,8 +115,8 @@ Six services compose the sync pipeline:
 - `CredentialResolver` — Resolves named values from credential profile
   `[resolve]` sections (value, file, and op sub-groups)
 - `OnePasswordClient` — Wraps `@1password/sdk` for 1Password secret references
-- `GitHubClient` — Octokit wrapper (19 methods); handles settings
-  (REST + GraphQL mutation), secrets by scope
+- `GitHubClient` — Octokit wrapper (20 methods, including `getOwnerType`);
+  handles settings (REST + GraphQL mutation), secrets by scope
   (actions/dependabot/codespaces/environments), variables by scope
   (actions/environments), rulesets, and deployment environments
 - `SyncEngine` — Orchestrates the full sync lifecycle: environments synced
@@ -158,8 +158,12 @@ undeclared), or `{ preserve = [...] }`.
 #### JSON Schema
 
 Run `pnpm --filter reposets generate:json-schema` to regenerate
-`package/schemas/`. Schema files use `x-tombi-*` annotations for
-[Tombi](https://tombi-toml.github.io/tombi/) TOML language server support.
+`package/schemas/`. The generation pipeline uses `xdg-effect` v0.3.1's
+`JsonSchemaExporter` service with `tombi()` helper for TOML language
+server annotations (`x-tombi-*`, `x-taplo`). Each schema includes a
+`$id` pointing to SchemaStore URLs. Ajv validates generated schemas in
+strict mode before writing. Script location:
+`package/lib/scripts/generate-json-schema.ts`.
 
 #### Fine-Grained Token Permissions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,9 +88,14 @@ rulesets = ["branch-protection"]
 
 ## Editor Support
 
-JSON schemas are generated for [Tombi](https://tombi-toml.github.io/tombi/) TOML language server support. Schema files include `x-tombi-*` annotations for inline documentation and completion.
+reposets publishes JSON schemas for both config files to [SchemaStore](https://www.schemastore.org/). Editors that support SchemaStore (VS Code, IntelliJ, Neovim, and others) will automatically detect `reposets.config.toml` and `reposets.credentials.toml` and provide validation, completion, and inline documentation with no manual setup required.
 
-Run `pnpm --filter reposets generate:json-schema` to regenerate schemas after config schema changes.
+The schemas also include annotations for two TOML-specific language servers:
+
+- [Tombi](https://tombi-toml.github.io/tombi/) -- `x-tombi-*` annotations for key ordering, additional key labels, and array value ordering
+- [Taplo](https://taplo.tamasfe.dev/) -- `x-taplo` annotations for documentation links and key scaffolding via `initKeys`
+
+If you use Tombi or Taplo as your TOML language server, you get richer editor integration including contextual documentation links that point to the relevant section of this documentation.
 
 ## Complete Example
 

--- a/package/lib/scripts/generate-json-schema.ts
+++ b/package/lib/scripts/generate-json-schema.ts
@@ -1,15 +1,44 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NodeFileSystem } from "@effect/platform-node";
+import _Ajv from "ajv";
+
+const Ajv = _Ajv as unknown as typeof _Ajv.default;
+
 import { Effect } from "effect";
-import { JsonSchemaExporter } from "xdg-effect";
+import type { JsonSchemaOutput } from "xdg-effect";
+import { JsonSchemaExporter, tombi } from "xdg-effect";
 import { ConfigSchema } from "../../src/schemas/config.js";
 import { CredentialsSchema } from "../../src/schemas/credentials.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outputDir = join(__dirname, "../../schemas");
 
-const tombiAnnotations = { "x-tombi-toml-version": "v1.1.0" };
+/** Custom extension keywords used in our schemas. */
+const CUSTOM_KEYWORDS = [
+	"x-tombi-additional-key-label",
+	"x-tombi-table-keys-order",
+	"x-tombi-array-values-order",
+	"x-tombi-array-values-order-by",
+	"x-tombi-string-formats",
+	"x-tombi-toml-version",
+	"x-taplo",
+] as const;
+
+function validateStrict(outputs: ReadonlyArray<JsonSchemaOutput>): void {
+	const ajv = new Ajv({ strict: true, strictTypes: false, allErrors: true });
+	for (const keyword of CUSTOM_KEYWORDS) {
+		ajv.addKeyword(keyword);
+	}
+	for (const output of outputs) {
+		try {
+			ajv.compile(output.schema);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			throw new Error(`Schema validation failed for "${output.name}": ${message}`);
+		}
+	}
+}
 
 const program = Effect.gen(function* () {
 	const exporter = yield* JsonSchemaExporter;
@@ -19,15 +48,19 @@ const program = Effect.gen(function* () {
 			name: "Config",
 			schema: ConfigSchema,
 			rootDefName: "Config",
-			annotations: tombiAnnotations,
+			$id: "https://json.schemastore.org/reposets.config.json",
+			annotations: tombi({ tomlVersion: "v1.1.0" }),
 		},
 		{
 			name: "Credentials",
 			schema: CredentialsSchema,
 			rootDefName: "Credentials",
-			annotations: tombiAnnotations,
+			$id: "https://json.schemastore.org/reposets.credentials.json",
+			annotations: tombi({ tomlVersion: "v1.1.0" }),
 		},
 	]);
+
+	validateStrict(outputs);
 
 	const results = yield* exporter.writeMany(
 		outputs.map((output) => ({

--- a/package/package.json
+++ b/package/package.json
@@ -58,12 +58,13 @@
 		"effect": "^3.21.1",
 		"smol-toml": ">=1.6.1",
 		"tweetnacl": "^1.0.3",
-		"xdg-effect": "^0.2.0"
+		"xdg-effect": "^0.3.1"
 	},
 	"devDependencies": {
 		"@savvy-web/rslib-builder": "^0.20.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
+		"ajv": "^8.18.0",
 		"tsx": "catalog:silk",
 		"typescript": "catalog:silk"
 	},
@@ -73,7 +74,7 @@
 	"publishConfig": {
 		"access": "public",
 		"directory": "dist/npm",
-		"linkDiectory": true,
+		"linkDirectory": true,
 		"targets": [
 			{
 				"protocol": "npm",

--- a/package/schemas/reposets.config.schema.json
+++ b/package/schemas/reposets.config.schema.json
@@ -20,19 +20,15 @@
 		},
 		"settings": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/SettingsGroup"
 			},
-			"description": "Named groups of GitHub repository settings (passed to the repos.update API)",
+			"description": "Named groups of GitHub repository settings to apply",
 			"title": "Settings groups",
 			"x-tombi-additional-key-label": "setting_group"
 		},
 		"secrets": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/SecretGroup"
 			},
@@ -42,8 +38,6 @@
 		},
 		"variables": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/VariableGroup"
 			},
@@ -53,19 +47,15 @@
 		},
 		"rulesets": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/Ruleset"
 			},
-			"description": "Named rulesets defining branch/tag/push protection rules",
+			"description": "Named rulesets defining branch and tag protection rules",
 			"title": "Rulesets",
 			"x-tombi-additional-key-label": "ruleset_name"
 		},
 		"environments": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/Environment"
 			},
@@ -75,20 +65,24 @@
 		},
 		"groups": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/Group"
 			},
-			"description": "Named groups of repositories with their settings, secrets, variables, and ruleset assignments",
+			"description": "Named groups of repositories with their settings, secrets, variables, rulesets, and environment assignments",
 			"title": "Groups",
 			"x-tombi-additional-key-label": "group_name"
 		}
 	},
 	"additionalProperties": false,
-	"description": "Configuration for syncing GitHub repository settings, secrets, variables, and rulesets",
+	"description": "Configuration for syncing GitHub repository settings, secrets, variables, rulesets, and deployment environments",
 	"title": "reposets Configuration",
 	"x-tombi-table-keys-order": "schema",
+	"x-taplo": {
+		"links": {
+			"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+		},
+		"initKeys": ["owner", "groups"]
+	},
 	"$defs": {
 		"LogLevel": {
 			"type": "string",
@@ -98,7 +92,6 @@
 		},
 		"SettingsGroup": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"is_template": {
 					"type": "boolean",
@@ -200,13 +193,15 @@
 					"title": "Require commit signoff"
 				}
 			},
-			"additionalProperties": {
-				"$id": "/schemas/unknown",
-				"title": "unknown"
-			},
+			"additionalProperties": {},
 			"description": "GitHub repository settings to apply. Known fields are typed; additional fields are passed through to the API.",
 			"title": "Settings group",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+				}
+			}
 		},
 		"SecretGroup": {
 			"anyOf": [
@@ -216,8 +211,6 @@
 					"properties": {
 						"file": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"type": "string"
 							},
@@ -234,8 +227,6 @@
 					"properties": {
 						"value": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"anyOf": [
 									{
@@ -243,12 +234,7 @@
 									},
 									{
 										"type": "object",
-										"required": [],
-										"properties": {},
-										"additionalProperties": {
-											"$id": "/schemas/unknown",
-											"title": "unknown"
-										}
+										"additionalProperties": {}
 									}
 								]
 							},
@@ -265,8 +251,6 @@
 					"properties": {
 						"resolved": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"type": "string"
 							},
@@ -279,7 +263,12 @@
 				}
 			],
 			"description": "A group of secrets. Must be exactly one kind: file, value, or resolved.",
-			"title": "Secret group"
+			"title": "Secret group",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/secrets-and-variables.md"
+				}
+			}
 		},
 		"VariableGroup": {
 			"anyOf": [
@@ -289,8 +278,6 @@
 					"properties": {
 						"file": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"type": "string"
 							},
@@ -307,8 +294,6 @@
 					"properties": {
 						"value": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"anyOf": [
 									{
@@ -316,12 +301,7 @@
 									},
 									{
 										"type": "object",
-										"required": [],
-										"properties": {},
-										"additionalProperties": {
-											"$id": "/schemas/unknown",
-											"title": "unknown"
-										}
+										"additionalProperties": {}
 									}
 								]
 							},
@@ -338,8 +318,6 @@
 					"properties": {
 						"resolved": {
 							"type": "object",
-							"required": [],
-							"properties": {},
 							"additionalProperties": {
 								"type": "string"
 							},
@@ -352,7 +330,12 @@
 				}
 			],
 			"description": "A group of variables. Must be exactly one kind: file, value, or resolved.",
-			"title": "Variable group"
+			"title": "Variable group",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/secrets-and-variables.md"
+				}
+			}
 		},
 		"Ruleset": {
 			"anyOf": [
@@ -365,7 +348,12 @@
 			],
 			"description": "A set of rules to apply when specified conditions are met",
 			"title": "Repository ruleset",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md"
+				}
+			}
 		},
 		"BranchRuleset": {
 			"type": "object",
@@ -394,32 +382,32 @@
 				"creation": {
 					"type": "boolean",
 					"description": "When true, adds a creation rule",
-					"title": "Creation shorthand"
+					"title": "Restrict creation"
 				},
 				"update": {
 					"type": "boolean",
 					"description": "When true, adds an update rule with update_allows_fetch_and_merge: true",
-					"title": "Update shorthand"
+					"title": "Restrict updates"
 				},
 				"deletion": {
 					"type": "boolean",
 					"description": "When true, adds a deletion rule",
-					"title": "Deletion shorthand"
+					"title": "Restrict deletion"
 				},
 				"required_linear_history": {
 					"type": "boolean",
 					"description": "When true, adds a required_linear_history rule",
-					"title": "Required linear history shorthand"
+					"title": "Require linear history"
 				},
 				"required_signatures": {
 					"type": "boolean",
 					"description": "When true, adds a required_signatures rule",
-					"title": "Required signatures shorthand"
+					"title": "Require signatures"
 				},
 				"non_fast_forward": {
 					"type": "boolean",
 					"description": "When true, adds a non_fast_forward rule",
-					"title": "Non-fast-forward shorthand"
+					"title": "Prevent non-fast-forward"
 				},
 				"deployments": {
 					"type": "array",
@@ -427,7 +415,7 @@
 						"type": "string"
 					},
 					"description": "Deployment environments that must succeed; converts to required_deployments rule",
-					"title": "Deployments shorthand"
+					"title": "Required deployments"
 				},
 				"targets": {
 					"$ref": "#/$defs/Targets"
@@ -497,11 +485,16 @@
 			"additionalProperties": false,
 			"description": "A ruleset that applies to branches",
 			"title": "Branch ruleset",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md"
+				},
+				"initKeys": ["name", "type", "enforcement", "targets"]
+			}
 		},
 		"RulesetConditions": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"ref_name": {
 					"$ref": "#/$defs/RefNameCondition"
@@ -513,7 +506,6 @@
 		},
 		"RefNameCondition": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"include": {
 					"type": "array",
@@ -673,7 +665,8 @@
 						"properties": {
 							"context": {
 								"type": "string",
-								"description": "The status check context name that must be present on the commit"
+								"description": "The status check context name that must be present on the commit",
+								"title": "Context"
 							},
 							"integration_id": {
 								"anyOf": [
@@ -684,7 +677,8 @@
 										"$ref": "#/$defs/ResolvedRef"
 									}
 								],
-								"description": "The integration ID, or a { resolved } reference to a credential label"
+								"description": "The integration ID, or a { resolved } reference to a credential label",
+								"title": "Integration ID"
 							}
 						},
 						"additionalProperties": false
@@ -729,7 +723,6 @@
 		},
 		"PullRequestsShorthand": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"approvals": {
 					"allOf": [
@@ -784,12 +777,13 @@
 								"items": {
 									"type": "string"
 								},
-								"description": "File patterns this reviewer must approve (fnmatch syntax)"
+								"description": "File patterns this reviewer must approve (fnmatch syntax)",
+								"title": "File patterns"
 							},
 							"minimum_approvals": {
 								"type": "integer",
 								"description": "Minimum approvals required from this team (0 = optional)",
-								"title": "int"
+								"title": "Minimum approvals"
 							},
 							"reviewer": {
 								"type": "object",
@@ -798,14 +792,15 @@
 									"id": {
 										"type": "integer",
 										"description": "Team ID",
-										"title": "int"
+										"title": "Team ID"
 									},
 									"type": {
 										"type": "string",
 										"enum": ["Team"]
 									}
 								},
-								"additionalProperties": false
+								"additionalProperties": false,
+								"title": "Reviewer team"
 							}
 						},
 						"additionalProperties": false
@@ -876,7 +871,6 @@
 		},
 		"CopilotReviewShorthand": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"draft_prs": {
 					"type": "boolean",
@@ -936,11 +930,13 @@
 						"properties": {
 							"path": {
 								"type": "string",
-								"description": "Path to the workflow file"
+								"description": "Path to the workflow file",
+								"title": "Workflow path"
 							},
 							"ref": {
 								"type": "string",
-								"description": "Branch or tag of the workflow file"
+								"description": "Branch or tag of the workflow file",
+								"title": "Ref"
 							},
 							"repository_id": {
 								"anyOf": [
@@ -951,11 +947,13 @@
 										"$ref": "#/$defs/ResolvedRef"
 									}
 								],
-								"description": "Repository ID, or a { resolved } reference to a credential label"
+								"description": "Repository ID, or a { resolved } reference to a credential label",
+								"title": "Repository ID"
 							},
 							"sha": {
 								"type": "string",
-								"description": "Commit SHA of the workflow file"
+								"description": "Commit SHA of the workflow file",
+								"title": "SHA"
 							}
 						},
 						"additionalProperties": false
@@ -995,32 +993,32 @@
 				"creation": {
 					"type": "boolean",
 					"description": "When true, adds a creation rule",
-					"title": "Creation shorthand"
+					"title": "Restrict creation"
 				},
 				"update": {
 					"type": "boolean",
 					"description": "When true, adds an update rule with update_allows_fetch_and_merge: true",
-					"title": "Update shorthand"
+					"title": "Restrict updates"
 				},
 				"deletion": {
 					"type": "boolean",
 					"description": "When true, adds a deletion rule",
-					"title": "Deletion shorthand"
+					"title": "Restrict deletion"
 				},
 				"required_linear_history": {
 					"type": "boolean",
 					"description": "When true, adds a required_linear_history rule",
-					"title": "Required linear history shorthand"
+					"title": "Require linear history"
 				},
 				"required_signatures": {
 					"type": "boolean",
 					"description": "When true, adds a required_signatures rule",
-					"title": "Required signatures shorthand"
+					"title": "Require signatures"
 				},
 				"non_fast_forward": {
 					"type": "boolean",
 					"description": "When true, adds a non_fast_forward rule",
-					"title": "Non-fast-forward shorthand"
+					"title": "Prevent non-fast-forward"
 				},
 				"deployments": {
 					"type": "array",
@@ -1028,7 +1026,7 @@
 						"type": "string"
 					},
 					"description": "Deployment environments that must succeed; converts to required_deployments rule",
-					"title": "Deployments shorthand"
+					"title": "Required deployments"
 				},
 				"targets": {
 					"$ref": "#/$defs/Targets"
@@ -1078,11 +1076,16 @@
 			"additionalProperties": false,
 			"description": "A ruleset that applies to tags",
 			"title": "Tag ruleset",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md"
+				},
+				"initKeys": ["name", "type", "enforcement", "targets"]
+			}
 		},
 		"Environment": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"wait_timer": {
 					"$ref": "#/$defs/Int",
@@ -1111,7 +1114,12 @@
 			"additionalProperties": false,
 			"description": "Configuration for a GitHub deployment environment",
 			"title": "Deployment environment",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/environments.md"
+				}
+			}
 		},
 		"Reviewer": {
 			"type": "object",
@@ -1125,7 +1133,7 @@
 				},
 				"id": {
 					"type": "integer",
-					"description": "The ID of the user or team",
+					"description": "The numeric GitHub ID of the user or team",
 					"title": "Reviewer ID"
 				}
 			},
@@ -1239,11 +1247,16 @@
 			"additionalProperties": false,
 			"description": "A named group of repositories with their resource assignments",
 			"title": "Repository group",
-			"x-tombi-table-keys-order": "schema"
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+				},
+				"initKeys": ["repos"]
+			}
 		},
 		"SecretScopes": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"actions": {
 					"type": "array",
@@ -1274,8 +1287,6 @@
 				},
 				"environments": {
 					"type": "object",
-					"required": [],
-					"properties": {},
 					"additionalProperties": {
 						"type": "array",
 						"items": {
@@ -1295,7 +1306,6 @@
 		},
 		"VariableScopes": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"actions": {
 					"type": "array",
@@ -1308,8 +1318,6 @@
 				},
 				"environments": {
 					"type": "object",
-					"required": [],
-					"properties": {},
 					"additionalProperties": {
 						"type": "array",
 						"items": {
@@ -1329,7 +1337,6 @@
 		},
 		"Cleanup": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"secrets": {
 					"allOf": [
@@ -1372,11 +1379,15 @@
 			},
 			"additionalProperties": false,
 			"description": "Controls deletion of resources not declared in config. All disabled by default.",
-			"title": "Cleanup configuration"
+			"title": "Cleanup configuration",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/cleanup.md"
+				}
+			}
 		},
 		"CleanupSecrets": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"actions": {
 					"allOf": [
@@ -1450,7 +1461,6 @@
 		},
 		"CleanupVariables": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"actions": {
 					"allOf": [
@@ -1478,5 +1488,6 @@
 			"title": "Variables cleanup configuration"
 		}
 	},
+	"$id": "https://json.schemastore.org/reposets.config.json",
 	"x-tombi-toml-version": "v1.1.0"
 }

--- a/package/schemas/reposets.credentials.schema.json
+++ b/package/schemas/reposets.credentials.schema.json
@@ -1,12 +1,9 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"type": "object",
-	"required": [],
 	"properties": {
 		"profiles": {
 			"type": "object",
-			"required": [],
-			"properties": {},
 			"additionalProperties": {
 				"$ref": "#/$defs/CredentialProfile"
 			},
@@ -18,6 +15,12 @@
 	"additionalProperties": false,
 	"description": "Authentication profiles for reposets. This file should be gitignored.",
 	"title": "reposets Credentials",
+	"x-taplo": {
+		"links": {
+			"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md"
+		},
+		"initKeys": ["profiles"]
+	},
 	"$defs": {
 		"CredentialProfile": {
 			"type": "object",
@@ -25,7 +28,7 @@
 			"properties": {
 				"github_token": {
 					"type": "string",
-					"description": "A GitHub personal access token (fine-grained) with repo administration and secrets permissions",
+					"description": "A GitHub personal access token (fine-grained) with administration, secrets, variables, environments, and GPG keys permissions",
 					"title": "GitHub token",
 					"examples": ["ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]
 				},
@@ -40,17 +43,20 @@
 				}
 			},
 			"additionalProperties": false,
-			"description": "Authentication credentials for a GitHub account with optional resolved value definitions",
-			"title": "Credential profile"
+			"description": "Authentication credentials for a GitHub account with optional named values for secret and variable resolution",
+			"title": "Credential profile",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md"
+				},
+				"initKeys": ["github_token"]
+			}
 		},
 		"ResolveSection": {
 			"type": "object",
-			"required": [],
 			"properties": {
 				"op": {
 					"type": "object",
-					"required": [],
-					"properties": {},
 					"additionalProperties": {
 						"type": "string"
 					},
@@ -60,8 +66,6 @@
 				},
 				"file": {
 					"type": "object",
-					"required": [],
-					"properties": {},
 					"additionalProperties": {
 						"type": "string"
 					},
@@ -71,8 +75,6 @@
 				},
 				"value": {
 					"type": "object",
-					"required": [],
-					"properties": {},
 					"additionalProperties": {
 						"anyOf": [
 							{
@@ -80,12 +82,7 @@
 							},
 							{
 								"type": "object",
-								"required": [],
-								"properties": {},
-								"additionalProperties": {
-									"$id": "/schemas/unknown",
-									"title": "unknown"
-								}
+								"additionalProperties": {}
 							}
 						]
 					},
@@ -95,9 +92,15 @@
 				}
 			},
 			"additionalProperties": false,
-			"description": "Named values resolved from 1Password, files, or inline. Referenced by config templates.",
-			"title": "Resolve section"
+			"description": "Named values resolved from 1Password, files, or inline. Referenced by resolved entries in secret and variable groups.",
+			"title": "Resolve section",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md"
+				}
+			}
 		}
 	},
+	"$id": "https://json.schemastore.org/reposets.credentials.json",
 	"x-tombi-toml-version": "v1.1.0"
 }

--- a/package/src/schemas/common.ts
+++ b/package/src/schemas/common.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { Jsonifiable, taplo, tombi } from "xdg-effect";
 
 // --- Resource Group Schemas ---
 
@@ -6,18 +7,18 @@ const ResourceFileKind = Schema.Struct({
 	file: Schema.Record({ key: Schema.String, value: Schema.String }).annotations({
 		title: "File entries",
 		description: "Named entries with file path values, resolved relative to config directory",
-		jsonSchema: { "x-tombi-additional-key-label": "name" },
+		jsonSchema: tombi({ additionalKeyLabel: "name" }),
 	}),
 });
 
 const ResourceValueKind = Schema.Struct({
 	value: Schema.Record({
 		key: Schema.String,
-		value: Schema.Union(Schema.String, Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+		value: Schema.Union(Schema.String, Schema.Record({ key: Schema.String, value: Jsonifiable })),
 	}).annotations({
 		title: "Value entries",
 		description: "Named entries with inline values. Strings used as-is, objects JSON-stringified.",
-		jsonSchema: { "x-tombi-additional-key-label": "name" },
+		jsonSchema: tombi({ additionalKeyLabel: "name" }),
 	}),
 });
 
@@ -25,7 +26,7 @@ const ResourceResolvedKind = Schema.Struct({
 	resolved: Schema.Record({ key: Schema.String, value: Schema.String }).annotations({
 		title: "Resolved entries",
 		description: "Named entries mapped to credential labels. Values come from the active credential profile.",
-		jsonSchema: { "x-tombi-additional-key-label": "name" },
+		jsonSchema: tombi({ additionalKeyLabel: "name" }),
 	}),
 });
 
@@ -33,6 +34,9 @@ export const SecretGroupSchema = Schema.Union(ResourceFileKind, ResourceValueKin
 	identifier: "SecretGroup",
 	title: "Secret group",
 	description: "A group of secrets. Must be exactly one kind: file, value, or resolved.",
+	jsonSchema: taplo({
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/secrets-and-variables.md" },
+	}),
 });
 
 export type SecretGroup = typeof SecretGroupSchema.Type;
@@ -41,6 +45,9 @@ export const VariableGroupSchema = Schema.Union(ResourceFileKind, ResourceValueK
 	identifier: "VariableGroup",
 	title: "Variable group",
 	description: "A group of variables. Must be exactly one kind: file, value, or resolved.",
+	jsonSchema: taplo({
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/secrets-and-variables.md" },
+	}),
 });
 
 export type VariableGroup = typeof VariableGroupSchema.Type;
@@ -144,6 +151,9 @@ export const CleanupSchema = Schema.Struct({
 	identifier: "Cleanup",
 	title: "Cleanup configuration",
 	description: "Controls deletion of resources not declared in config. All disabled by default.",
+	jsonSchema: taplo({
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/cleanup.md" },
+	}),
 });
 
 export type Cleanup = typeof CleanupSchema.Type;

--- a/package/src/schemas/config.ts
+++ b/package/src/schemas/config.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { Jsonifiable, taplo, tombi } from "xdg-effect";
 import { CleanupSchema, SecretGroupSchema, VariableGroupSchema } from "./common.js";
 import { EnvironmentSchema } from "./environment.js";
 import { RulesetSchema } from "./ruleset.js";
@@ -35,7 +36,7 @@ export const SecretScopesSchema = Schema.Struct({
 		}).annotations({
 			title: "Environment secret scopes",
 			description: "Map of environment names to secret group references",
-			jsonSchema: { "x-tombi-additional-key-label": "environment_name" },
+			jsonSchema: tombi({ additionalKeyLabel: "environment_name" }),
 		}),
 	),
 }).annotations({
@@ -62,7 +63,7 @@ export const VariableScopesSchema = Schema.Struct({
 		}).annotations({
 			title: "Environment variable scopes",
 			description: "Map of environment names to variable group references",
-			jsonSchema: { "x-tombi-additional-key-label": "environment_name" },
+			jsonSchema: tombi({ additionalKeyLabel: "environment_name" }),
 		}),
 	),
 }).annotations({
@@ -83,7 +84,7 @@ export const GroupSchema = Schema.Struct({
 		title: "Repository names",
 		description: "List of repository names (without owner prefix) to sync in this group",
 		examples: [["repo-one", "repo-two", "repo-three"]],
-		jsonSchema: { "x-tombi-array-values-order": "ascending" },
+		jsonSchema: tombi({ arrayValuesOrder: "ascending" }),
 	}),
 	credentials: Schema.optional(
 		Schema.String.annotations({
@@ -120,7 +121,13 @@ export const GroupSchema = Schema.Struct({
 	identifier: "Group",
 	title: "Repository group",
 	description: "A named group of repositories with their resource assignments",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			initKeys: ["repos"],
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
 });
 
 export type Group = typeof GroupSchema.Type;
@@ -246,13 +253,18 @@ const SettingsGroupSchema = Schema.Struct(
 			}),
 		),
 	},
-	{ key: Schema.String, value: Schema.Unknown },
+	{ key: Schema.String, value: Jsonifiable },
 ).annotations({
 	identifier: "SettingsGroup",
 	title: "Settings group",
 	description:
 		"GitHub repository settings to apply. Known fields are typed; additional fields are passed through to the API.",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
 });
 
 export const LogLevelSchema = Schema.Literal("silent", "info", "verbose", "debug").annotations({
@@ -279,8 +291,8 @@ export const ConfigSchema = Schema.Struct({
 	settings: Schema.optionalWith(
 		Schema.Record({ key: Schema.String, value: SettingsGroupSchema }).annotations({
 			title: "Settings groups",
-			description: "Named groups of GitHub repository settings (passed to the repos.update API)",
-			jsonSchema: { "x-tombi-additional-key-label": "setting_group" },
+			description: "Named groups of GitHub repository settings to apply",
+			jsonSchema: tombi({ additionalKeyLabel: "setting_group" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -288,7 +300,7 @@ export const ConfigSchema = Schema.Struct({
 		Schema.Record({ key: Schema.String, value: SecretGroupSchema }).annotations({
 			title: "Secret groups",
 			description: "Named groups of secrets. Each group is one kind: file, value, or resolved.",
-			jsonSchema: { "x-tombi-additional-key-label": "secret_group" },
+			jsonSchema: tombi({ additionalKeyLabel: "secret_group" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -296,7 +308,7 @@ export const ConfigSchema = Schema.Struct({
 		Schema.Record({ key: Schema.String, value: VariableGroupSchema }).annotations({
 			title: "Variable groups",
 			description: "Named groups of variables. Each group is one kind: file, value, or resolved.",
-			jsonSchema: { "x-tombi-additional-key-label": "variable_group" },
+			jsonSchema: tombi({ additionalKeyLabel: "variable_group" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -306,8 +318,8 @@ export const ConfigSchema = Schema.Struct({
 			value: RulesetSchema,
 		}).annotations({
 			title: "Rulesets",
-			description: "Named rulesets defining branch/tag/push protection rules",
-			jsonSchema: { "x-tombi-additional-key-label": "ruleset_name" },
+			description: "Named rulesets defining branch and tag protection rules",
+			jsonSchema: tombi({ additionalKeyLabel: "ruleset_name" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -318,7 +330,7 @@ export const ConfigSchema = Schema.Struct({
 		}).annotations({
 			title: "Environments",
 			description: "Named deployment environment configurations",
-			jsonSchema: { "x-tombi-additional-key-label": "environment_name" },
+			jsonSchema: tombi({ additionalKeyLabel: "environment_name" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -327,14 +339,22 @@ export const ConfigSchema = Schema.Struct({
 		value: GroupSchema,
 	}).annotations({
 		title: "Groups",
-		description: "Named groups of repositories with their settings, secrets, variables, and ruleset assignments",
-		jsonSchema: { "x-tombi-additional-key-label": "group_name" },
+		description:
+			"Named groups of repositories with their settings, secrets, variables, rulesets, and environment assignments",
+		jsonSchema: tombi({ additionalKeyLabel: "group_name" }),
 	}),
 }).annotations({
 	identifier: "Config",
 	title: "reposets Configuration",
-	description: "Configuration for syncing GitHub repository settings, secrets, variables, and rulesets",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	description:
+		"Configuration for syncing GitHub repository settings, secrets, variables, rulesets, and deployment environments",
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			initKeys: ["owner", "groups"],
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
 });
 
 export type Config = typeof ConfigSchema.Type;

--- a/package/src/schemas/credentials.ts
+++ b/package/src/schemas/credentials.ts
@@ -1,34 +1,39 @@
 import { Schema } from "effect";
+import { Jsonifiable, taplo, tombi } from "xdg-effect";
 
 export const ResolveSectionSchema = Schema.Struct({
 	op: Schema.optional(
 		Schema.Record({ key: Schema.String, value: Schema.String }).annotations({
 			title: "1Password references",
 			description: "Named values resolved via 1Password SDK. Values are op:// reference strings.",
-			jsonSchema: { "x-tombi-additional-key-label": "label" },
+			jsonSchema: tombi({ additionalKeyLabel: "label" }),
 		}),
 	),
 	file: Schema.optional(
 		Schema.Record({ key: Schema.String, value: Schema.String }).annotations({
 			title: "File references",
 			description: "Named values read from files. Values are file paths relative to the credentials directory.",
-			jsonSchema: { "x-tombi-additional-key-label": "label" },
+			jsonSchema: tombi({ additionalKeyLabel: "label" }),
 		}),
 	),
 	value: Schema.optional(
 		Schema.Record({
 			key: Schema.String,
-			value: Schema.Union(Schema.String, Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+			value: Schema.Union(Schema.String, Schema.Record({ key: Schema.String, value: Jsonifiable })),
 		}).annotations({
 			title: "Inline values",
 			description: "Named inline values. Strings are used as-is, objects are JSON-stringified.",
-			jsonSchema: { "x-tombi-additional-key-label": "label" },
+			jsonSchema: tombi({ additionalKeyLabel: "label" }),
 		}),
 	),
 }).annotations({
 	identifier: "ResolveSection",
 	title: "Resolve section",
-	description: "Named values resolved from 1Password, files, or inline. Referenced by config templates.",
+	description:
+		"Named values resolved from 1Password, files, or inline. Referenced by resolved entries in secret and variable groups.",
+	jsonSchema: taplo({
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md" },
+	}),
 });
 
 export type ResolveSection = typeof ResolveSectionSchema.Type;
@@ -36,7 +41,8 @@ export type ResolveSection = typeof ResolveSectionSchema.Type;
 export const CredentialProfileSchema = Schema.Struct({
 	github_token: Schema.String.annotations({
 		title: "GitHub token",
-		description: "A GitHub personal access token (fine-grained) with repo administration and secrets permissions",
+		description:
+			"A GitHub personal access token (fine-grained) with administration, secrets, variables, environments, and GPG keys permissions",
 		examples: ["ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"],
 	}),
 	op_service_account_token: Schema.optional(
@@ -50,7 +56,12 @@ export const CredentialProfileSchema = Schema.Struct({
 }).annotations({
 	identifier: "CredentialProfile",
 	title: "Credential profile",
-	description: "Authentication credentials for a GitHub account with optional resolved value definitions",
+	description:
+		"Authentication credentials for a GitHub account with optional named values for secret and variable resolution",
+	jsonSchema: taplo({
+		initKeys: ["github_token"],
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md" },
+	}),
 });
 
 export type CredentialProfile = typeof CredentialProfileSchema.Type;
@@ -61,7 +72,7 @@ export const CredentialsSchema = Schema.Struct({
 			title: "Credential profiles",
 			description:
 				"Named credential profiles. If only one profile is defined, it is used automatically for all repo groups.",
-			jsonSchema: { "x-tombi-additional-key-label": "profile_name" },
+			jsonSchema: tombi({ additionalKeyLabel: "profile_name" }),
 		}),
 		{ default: () => ({}) },
 	),
@@ -69,6 +80,10 @@ export const CredentialsSchema = Schema.Struct({
 	identifier: "Credentials",
 	title: "reposets Credentials",
 	description: "Authentication profiles for reposets. This file should be gitignored.",
+	jsonSchema: taplo({
+		initKeys: ["profiles"],
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/credentials.md" },
+	}),
 });
 
 export type Credentials = typeof CredentialsSchema.Type;

--- a/package/src/schemas/environment.ts
+++ b/package/src/schemas/environment.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { taplo, tombi } from "xdg-effect";
 
 // --- Reviewer ---
 
@@ -11,7 +12,7 @@ const ReviewerSchema = Schema.Struct({
 	type: ReviewerTypeSchema,
 	id: Schema.Int.annotations({
 		title: "Reviewer ID",
-		description: "The ID of the user or team",
+		description: "The numeric GitHub ID of the user or team",
 	}),
 }).annotations({
 	identifier: "Reviewer",
@@ -82,7 +83,12 @@ export const EnvironmentSchema = Schema.Struct({
 	identifier: "Environment",
 	title: "Deployment environment",
 	description: "Configuration for a GitHub deployment environment",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/environments.md" },
+		}),
+	},
 });
 
 export type Environment = typeof EnvironmentSchema.Type;

--- a/package/src/schemas/ruleset.ts
+++ b/package/src/schemas/ruleset.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect";
+import { taplo, tombi } from "xdg-effect";
 
 export const ResolvedRefSchema = Schema.Struct({
 	resolved: Schema.String.annotations({
@@ -84,35 +85,40 @@ export const RulesetConditionsSchema = Schema.Struct({
 
 const RequiredReviewerSchema = Schema.Struct({
 	file_patterns: Schema.Array(Schema.String).annotations({
+		title: "File patterns",
 		description: "File patterns this reviewer must approve (fnmatch syntax)",
 	}),
 	minimum_approvals: Schema.Int.annotations({
+		title: "Minimum approvals",
 		description: "Minimum approvals required from this team (0 = optional)",
 	}),
 	reviewer: Schema.Struct({
-		id: Schema.Int.annotations({ description: "Team ID" }),
+		id: Schema.Int.annotations({ title: "Team ID", description: "Team ID" }),
 		type: Schema.Literal("Team"),
-	}),
+	}).annotations({ title: "Reviewer team" }),
 });
 
 const StatusCheckSchema = Schema.Struct({
 	context: Schema.String.annotations({
+		title: "Context",
 		description: "The status check context name that must be present on the commit",
 	}),
 	integration_id: Schema.optional(
 		Schema.Union(Schema.Int, ResolvedRefSchema).annotations({
+			title: "Integration ID",
 			description: "The integration ID, or a { resolved } reference to a credential label",
 		}),
 	),
 });
 
 const WorkflowFileSchema = Schema.Struct({
-	path: Schema.String.annotations({ description: "Path to the workflow file" }),
-	ref: Schema.optional(Schema.String.annotations({ description: "Branch or tag of the workflow file" })),
+	path: Schema.String.annotations({ title: "Workflow path", description: "Path to the workflow file" }),
+	ref: Schema.optional(Schema.String.annotations({ title: "Ref", description: "Branch or tag of the workflow file" })),
 	repository_id: Schema.Union(Schema.Int, ResolvedRefSchema).annotations({
+		title: "Repository ID",
 		description: "Repository ID, or a { resolved } reference to a credential label",
 	}),
-	sha: Schema.optional(Schema.String.annotations({ description: "Commit SHA of the workflow file" })),
+	sha: Schema.optional(Schema.String.annotations({ title: "SHA", description: "Commit SHA of the workflow file" })),
 });
 
 // --- Targets Shorthand ---
@@ -379,43 +385,43 @@ const sharedRulesetFields = {
 	// Boolean shorthands
 	creation: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Creation shorthand",
+			title: "Restrict creation",
 			description: "When true, adds a creation rule",
 		}),
 	),
 	update: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Update shorthand",
+			title: "Restrict updates",
 			description: "When true, adds an update rule with update_allows_fetch_and_merge: true",
 		}),
 	),
 	deletion: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Deletion shorthand",
+			title: "Restrict deletion",
 			description: "When true, adds a deletion rule",
 		}),
 	),
 	required_linear_history: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Required linear history shorthand",
+			title: "Require linear history",
 			description: "When true, adds a required_linear_history rule",
 		}),
 	),
 	required_signatures: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Required signatures shorthand",
+			title: "Require signatures",
 			description: "When true, adds a required_signatures rule",
 		}),
 	),
 	non_fast_forward: Schema.optional(
 		Schema.Boolean.annotations({
-			title: "Non-fast-forward shorthand",
+			title: "Prevent non-fast-forward",
 			description: "When true, adds a non_fast_forward rule",
 		}),
 	),
 	deployments: Schema.optional(
 		Schema.Array(Schema.String).annotations({
-			title: "Deployments shorthand",
+			title: "Required deployments",
 			description: "Deployment environments that must succeed; converts to required_deployments rule",
 		}),
 	),
@@ -470,7 +476,13 @@ export const BranchRulesetSchema = Schema.Struct({
 	identifier: "BranchRuleset",
 	title: "Branch ruleset",
 	description: "A ruleset that applies to branches",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			initKeys: ["name", "type", "enforcement", "targets"],
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md" },
+		}),
+	},
 });
 
 // --- Tag Ruleset ---
@@ -491,7 +503,13 @@ export const TagRulesetSchema = Schema.Struct({
 	identifier: "TagRuleset",
 	title: "Tag ruleset",
 	description: "A ruleset that applies to tags",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			initKeys: ["name", "type", "enforcement", "targets"],
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md" },
+		}),
+	},
 });
 
 // --- Top-level Ruleset (discriminated union) ---
@@ -500,7 +518,12 @@ export const RulesetSchema = Schema.Union(BranchRulesetSchema, TagRulesetSchema)
 	identifier: "Ruleset",
 	title: "Repository ruleset",
 	description: "A set of rules to apply when specified conditions are met",
-	jsonSchema: { "x-tombi-table-keys-order": "schema" },
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md" },
+		}),
+	},
 });
 
 export type Ruleset = typeof RulesetSchema.Type;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       xdg-effect:
-        specifier: ^0.2.0
-        version: 0.2.0(03f80dd67552833d8eca5052e274b981)
+        specifier: ^0.3.1
+        version: 0.3.1(f48556a8145cf8e2eb56e6c16980f1a6)
     devDependencies:
       '@savvy-web/rslib-builder':
         specifier: ^0.20.1
@@ -97,6 +97,9 @@ importers:
       '@typescript/native-preview':
         specifier: catalog:silk
         version: 7.0.0-dev.20260418.1
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
       tsx:
         specifier: catalog:silk
         version: 4.21.0
@@ -4292,13 +4295,14 @@ packages:
       utf-8-validate:
         optional: true
 
-  xdg-effect@0.2.0:
-    resolution: {integrity: sha512-fUWxvUvfYIbWc1lU45bhkAm/vHuik+ymlA2phbuL5/re+R+lrOt9ZJrqZHi6mYGIhJNfmGBhEhPSiB5a7glcPw==}
+  xdg-effect@0.3.1:
+    resolution: {integrity: sha512-6Ka/Kf4NI8w+LJF6gkC6ChCTq7lP38RvMntSDFd09rUfFoBMIeq4mQ24LHORq0yF26sAE6FHA4M6OJiNQqjOjg==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       '@effect/platform-node': '>=0.106.0'
       '@effect/sql': '>=0.51.0'
       '@effect/sql-sqlite-node': '>=0.52.0'
+      ajv: '>=8.0.0'
       effect: '>=3.21.0'
     peerDependenciesMeta:
       '@effect/platform-node':
@@ -4306,6 +4310,8 @@ packages:
       '@effect/sql':
         optional: true
       '@effect/sql-sqlite-node':
+        optional: true
+      ajv:
         optional: true
 
   y18n@5.0.8:
@@ -8943,7 +8949,7 @@ snapshots:
 
   ws@8.20.0: {}
 
-  xdg-effect@0.2.0(03f80dd67552833d8eca5052e274b981):
+  xdg-effect@0.3.1(f48556a8145cf8e2eb56e6c16980f1a6):
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.1)
       effect: 3.21.1
@@ -8952,6 +8958,7 @@ snapshots:
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
       '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      ajv: 8.18.0
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

- Prepare JSON Schemas for SchemaStore submission with `$id` URLs and Ajv strict-mode validation
- Add `x-taplo` annotations (initKeys, documentation links) for Taplo TOML language server
- Migrate `x-tombi-*` annotations to typed `tombi()` helper from xdg-effect v0.3.1
- Replace `Schema.Unknown` with `Jsonifiable` for clean schema output
- Improve schema descriptions, titles, and add missing annotations across all definitions
- Add ajv as devDependency for direct strict-mode validation with custom keyword registration

## Test plan

- [ ] `pnpm run build` passes (includes schema generation + Ajv validation)
- [ ] `pnpm run test` passes (235 tests)
- [ ] `pnpm run lint` passes
- [ ] Generated schemas contain `$id` pointing to SchemaStore URLs
- [ ] No `$id: /schemas/unknown` artifacts in generated schemas
- [ ] No empty `required: []` arrays in generated schemas
- [ ] `x-taplo` annotations present in generated schemas

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>