### PR TITLE
fix(schemas): update $id URLs and use JsonSchemaValidator

### DIFF
--- a/.changeset/fix-schemastore-id.md
+++ b/.changeset/fix-schemastore-id.md
@@ -1,0 +1,29 @@
+---
+"reposets": patch
+---
+
+## Bug Fixes
+
+### JSON Schema `$id` URLs
+
+Updated `$id` values in generated JSON schemas to point to the actual hosting
+location on GitHub rather than SchemaStore URLs that never resolve for
+externally-hosted schemas.
+
+- `reposets.config.schema.json` now uses its raw GitHub URL as `$id`
+- `reposets.credentials.schema.json` now uses its raw GitHub URL as `$id`
+
+### Schema Generation Pipeline
+
+Replaced hand-rolled Ajv validation with xdg-effect's `JsonSchemaValidator`
+service. The generation script now uses the standard
+`generateMany` -> `validateMany` -> `writeMany` pipeline.
+
+## Dependencies
+
+- Upgraded `xdg-effect` from 0.3.1 to 0.3.3
+
+## Maintenance
+
+- Fixed invalid `x-tombi-table-keys-order` annotation on `RulesetSchema` union
+  node (now only on the individual struct members where it is valid)

--- a/.claude/design/reposets/config-format.md
+++ b/.claude/design/reposets/config-format.md
@@ -274,20 +274,22 @@ labels referenced by config templates.
 ## JSON Schema Generation
 
 Effect Schema definitions generate JSON schemas via `JsonSchemaExporter`
-from xdg-effect (v0.3.1). The generation script
-(`package/lib/scripts/generate-json-schema.ts`):
+from xdg-effect (v0.3.3). The generation script
+(`package/lib/scripts/generate-json-schema.ts`) uses the standard
+`generateMany` -> `validateMany` -> `writeMany` pipeline:
 
 1. Calls `JsonSchemaExporter.generateMany()` with schema definitions,
-   root def names, and SchemaStore `$id` URLs
-2. Runs Ajv strict-mode validation on the generated schemas with all
-   custom extension keywords registered (`x-tombi-*`, `x-taplo`)
+   root def names, and `$id` URLs
+2. Calls `JsonSchemaValidator.validateMany()` for strict-mode validation
+   (custom extension keywords `x-tombi-*`, `x-taplo` are handled
+   internally by the validator service)
 3. Writes output via `JsonSchemaExporter.writeMany()` to
    `package/schemas/` (only writes when content changed)
 
-SchemaStore `$id` values:
+`$id` values (externally hosted on GitHub):
 
-- Config: `https://json.schemastore.org/reposets.config.json`
-- Credentials: `https://json.schemastore.org/reposets.credentials.json`
+- Config: `https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json`
+- Credentials: `https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json`
 
 ### Schema Annotations
 
@@ -319,7 +321,5 @@ for those positions. Three files use `Jsonifiable`: `common.ts`
 
 ### Dependencies
 
-- `xdg-effect` (^0.3.1) -- `JsonSchemaExporter`, `Jsonifiable`,
-  `tombi()`, `taplo()` helpers
-- `ajv` (^8.18.0, devDependency) -- strict-mode schema validation
-  during generation
+- `xdg-effect` (^0.3.3) -- `JsonSchemaExporter`, `JsonSchemaValidator`,
+  `Jsonifiable`, `tombi()`, `taplo()` helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,11 +158,12 @@ undeclared), or `{ preserve = [...] }`.
 #### JSON Schema
 
 Run `pnpm --filter reposets generate:json-schema` to regenerate
-`package/schemas/`. The generation pipeline uses `xdg-effect` v0.3.1's
-`JsonSchemaExporter` service with `tombi()` helper for TOML language
-server annotations (`x-tombi-*`, `x-taplo`). Each schema includes a
-`$id` pointing to SchemaStore URLs. Ajv validates generated schemas in
-strict mode before writing. Script location:
+`package/schemas/`. The generation pipeline uses `xdg-effect` v0.3.3's
+`JsonSchemaExporter` and `JsonSchemaValidator` services with `tombi()`
+and `taplo()` helpers for TOML language server annotations. Each schema
+includes a `$id` pointing to the raw GitHub hosting URL.
+`JsonSchemaValidator` validates in strict mode (Ajv strict + annotation
+placement checks) before writing. Script location:
 `package/lib/scripts/generate-json-schema.ts`.
 
 #### Fine-Grained Token Permissions

--- a/package/lib/scripts/generate-json-schema.ts
+++ b/package/lib/scripts/generate-json-schema.ts
@@ -1,83 +1,47 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { NodeFileSystem } from "@effect/platform-node";
-import _Ajv from "ajv";
-
-const Ajv = _Ajv as unknown as typeof _Ajv.default;
-
-import { Effect } from "effect";
-import type { JsonSchemaOutput } from "xdg-effect";
-import { JsonSchemaExporter, tombi } from "xdg-effect";
+import { Effect, Layer } from "effect";
+import { JsonSchemaExporter, JsonSchemaValidator, tombi } from "xdg-effect";
 import { ConfigSchema } from "../../src/schemas/config.js";
 import { CredentialsSchema } from "../../src/schemas/credentials.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const outputDir = join(__dirname, "../../schemas");
 
-/** Custom extension keywords used in our schemas. */
-const CUSTOM_KEYWORDS = [
-	"x-tombi-additional-key-label",
-	"x-tombi-table-keys-order",
-	"x-tombi-array-values-order",
-	"x-tombi-array-values-order-by",
-	"x-tombi-string-formats",
-	"x-tombi-toml-version",
-	"x-taplo",
+const entries = [
+	{
+		name: "Config",
+		schema: ConfigSchema,
+		rootDefName: "Config",
+		$id: "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json",
+		annotations: tombi({ tomlVersion: "v1.1.0" }),
+	},
+	{
+		name: "Credentials",
+		schema: CredentialsSchema,
+		rootDefName: "Credentials",
+		$id: "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json",
+		annotations: tombi({ tomlVersion: "v1.1.0" }),
+	},
 ] as const;
-
-function validateStrict(outputs: ReadonlyArray<JsonSchemaOutput>): void {
-	const ajv = new Ajv({ strict: true, strictTypes: false, allErrors: true });
-	for (const keyword of CUSTOM_KEYWORDS) {
-		ajv.addKeyword(keyword);
-	}
-	for (const output of outputs) {
-		try {
-			ajv.compile(output.schema);
-		} catch (error) {
-			const message = error instanceof Error ? error.message : String(error);
-			throw new Error(`Schema validation failed for "${output.name}": ${message}`);
-		}
-	}
-}
 
 const program = Effect.gen(function* () {
 	const exporter = yield* JsonSchemaExporter;
+	const validator = yield* JsonSchemaValidator;
 
-	const outputs = yield* exporter.generateMany([
-		{
-			name: "Config",
-			schema: ConfigSchema,
-			rootDefName: "Config",
-			$id: "https://json.schemastore.org/reposets.config.json",
-			annotations: tombi({ tomlVersion: "v1.1.0" }),
-		},
-		{
-			name: "Credentials",
-			schema: CredentialsSchema,
-			rootDefName: "Credentials",
-			$id: "https://json.schemastore.org/reposets.credentials.json",
-			annotations: tombi({ tomlVersion: "v1.1.0" }),
-		},
-	]);
-
-	validateStrict(outputs);
-
-	const results = yield* exporter.writeMany(
-		outputs.map((output) => ({
+	const outputs = yield* exporter.generateMany(entries);
+	const validated = yield* validator.validateMany(outputs, { strict: true });
+	yield* exporter.writeMany(
+		validated.map((output) => ({
 			output,
 			path: join(outputDir, `reposets.${output.name.toLowerCase()}.schema.json`),
 		})),
 	);
-
-	for (let i = 0; i < results.length; i++) {
-		const result = results[i];
-		const name = outputs[i].name;
-		if (result._tag === "Written") {
-			console.log(`  ${name}: generated -> ${result.path}`);
-		} else {
-			console.log(`  ${name}: unchanged`);
-		}
-	}
 });
 
-Effect.runPromise(program.pipe(Effect.provide(JsonSchemaExporter.Live), Effect.provide(NodeFileSystem.layer)));
+const MainLayer = Layer.mergeAll(JsonSchemaExporter.Live, JsonSchemaValidator.Live).pipe(
+	Layer.provide(NodeFileSystem.layer),
+);
+
+Effect.runPromise(program.pipe(Effect.provide(MainLayer)));

--- a/package/package.json
+++ b/package/package.json
@@ -58,7 +58,7 @@
 		"effect": "^3.21.1",
 		"smol-toml": ">=1.6.1",
 		"tweetnacl": "^1.0.3",
-		"xdg-effect": "^0.3.1"
+		"xdg-effect": "^0.3.3"
 	},
 	"devDependencies": {
 		"@savvy-web/rslib-builder": "^0.20.1",

--- a/package/schemas/reposets.config.schema.json
+++ b/package/schemas/reposets.config.schema.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json",
 	"type": "object",
 	"required": ["groups"],
 	"properties": {
@@ -348,7 +349,6 @@
 			],
 			"description": "A set of rules to apply when specified conditions are met",
 			"title": "Repository ruleset",
-			"x-tombi-table-keys-order": "schema",
 			"x-taplo": {
 				"links": {
 					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md"
@@ -1488,6 +1488,5 @@
 			"title": "Variables cleanup configuration"
 		}
 	},
-	"$id": "https://json.schemastore.org/reposets.config.json",
 	"x-tombi-toml-version": "v1.1.0"
 }

--- a/package/schemas/reposets.credentials.schema.json
+++ b/package/schemas/reposets.credentials.schema.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json",
 	"type": "object",
 	"properties": {
 		"profiles": {
@@ -101,6 +102,5 @@
 			}
 		}
 	},
-	"$id": "https://json.schemastore.org/reposets.credentials.json",
 	"x-tombi-toml-version": "v1.1.0"
 }

--- a/package/src/schemas/ruleset.ts
+++ b/package/src/schemas/ruleset.ts
@@ -518,12 +518,9 @@ export const RulesetSchema = Schema.Union(BranchRulesetSchema, TagRulesetSchema)
 	identifier: "Ruleset",
 	title: "Repository ruleset",
 	description: "A set of rules to apply when specified conditions are met",
-	jsonSchema: {
-		...tombi({ tableKeysOrder: "schema" }),
-		...taplo({
-			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md" },
-		}),
-	},
+	jsonSchema: taplo({
+		links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md" },
+	}),
 });
 
 export type Ruleset = typeof RulesetSchema.Type;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       xdg-effect:
-        specifier: ^0.3.1
-        version: 0.3.1(f48556a8145cf8e2eb56e6c16980f1a6)
+        specifier: ^0.3.3
+        version: 0.3.3(f48556a8145cf8e2eb56e6c16980f1a6)
     devDependencies:
       '@savvy-web/rslib-builder':
         specifier: ^0.20.1
@@ -394,6 +394,11 @@ packages:
     resolution: {integrity: sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A==}
     peerDependencies:
       effect: ^3.21.0
+
+  '@effect/platform@0.96.1':
+    resolution: {integrity: sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A==}
+    peerDependencies:
+      effect: ^3.21.2
 
   '@effect/printer-ansi@0.49.0':
     resolution: {integrity: sha512-N2OyqDTqcGLKeUy2URowThoU5issZQwG/Ihv5qOYWJD0neq9qBIgC57/9BkFpTRPNSMtPHyCOk1TFj297HGLLQ==}
@@ -4295,8 +4300,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  xdg-effect@0.3.1:
-    resolution: {integrity: sha512-6Ka/Kf4NI8w+LJF6gkC6ChCTq7lP38RvMntSDFd09rUfFoBMIeq4mQ24LHORq0yF26sAE6FHA4M6OJiNQqjOjg==}
+  xdg-effect@0.3.3:
+    resolution: {integrity: sha512-GDlx4OXuJfSFR/9ABp4m3eljgDPuaBUYdx7+UZZmiXq2YGMQKzzLRoIQ7StkwOJ4QXe6Q8mqVlHus6Txd7iYkw==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       '@effect/platform-node': '>=0.106.0'
@@ -4719,6 +4724,16 @@ snapshots:
       toml: 3.0.0
       yaml: 2.8.3
 
+  '@effect/cli@0.75.1(@effect/platform@0.96.1(effect@3.21.1))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.1)
+      '@effect/printer': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1)
+      '@effect/printer-ansi': 0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1)
+      effect: 3.21.1
+      ini: 4.1.3
+      toml: 3.0.0
+      yaml: 2.8.3
+
   '@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.1)
@@ -4748,6 +4763,20 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
+    dependencies:
+      '@effect/cluster': 0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/platform': 0.96.1(effect@3.21.1)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      '@parcel/watcher': 2.5.6
+      effect: 3.21.1
+      multipasta: 0.2.7
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform-node@0.106.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
     dependencies:
       '@effect/cluster': 0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
@@ -4763,7 +4792,29 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@effect/platform-node@0.106.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
+    dependencies:
+      '@effect/cluster': 0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/platform': 0.96.1(effect@3.21.1)
+      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/rpc': 0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      effect: 3.21.1
+      mime: 3.0.0
+      undici: 7.25.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@effect/platform@0.96.0(effect@3.21.1)':
+    dependencies:
+      effect: 3.21.1
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.10
+      multipasta: 0.2.7
+
+  '@effect/platform@0.96.1(effect@3.21.1)':
     dependencies:
       effect: 3.21.1
       find-my-way-ts: 0.1.6
@@ -4794,11 +4845,27 @@ snapshots:
       '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
       better-sqlite3: 12.9.0
       effect: 3.21.1
+    optional: true
+
+  '@effect/sql-sqlite-node@0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)':
+    dependencies:
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      '@effect/platform': 0.96.1(effect@3.21.1)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      better-sqlite3: 12.9.0
+      effect: 3.21.1
 
   '@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)':
     dependencies:
       '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
       '@effect/platform': 0.96.0(effect@3.21.1)
+      effect: 3.21.1
+      uuid: 11.1.0
+
+  '@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(effect@3.21.1)':
+    dependencies:
+      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
+      '@effect/platform': 0.96.1(effect@3.21.1)
       effect: 3.21.1
       uuid: 11.1.0
 
@@ -8797,11 +8864,11 @@ snapshots:
 
   vitest-agent-reporter@1.2.1(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@vitest/coverage-v8@4.1.4)(typescript@6.0.3)(vitest@4.1.4):
     dependencies:
-      '@effect/cli': 0.75.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
-      '@effect/platform': 0.96.0(effect@3.21.1)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1)
-      '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.1))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/platform': 0.96.1(effect@3.21.1)
+      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.1(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
+      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(effect@3.21.1)
+      '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.1(effect@3.21.1))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(@effect/platform@0.96.0(effect@3.21.1))(effect@3.21.1))(effect@3.21.1)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       '@trpc/server': 11.16.0(typescript@6.0.3)
       effect: 3.21.1
@@ -8949,7 +9016,7 @@ snapshots:
 
   ws@8.20.0: {}
 
-  xdg-effect@0.3.1(f48556a8145cf8e2eb56e6c16980f1a6):
+  xdg-effect@0.3.3(f48556a8145cf8e2eb56e6c16980f1a6):
     dependencies:
       '@effect/platform': 0.96.0(effect@3.21.1)
       effect: 3.21.1


### PR DESCRIPTION
## Summary

- Update JSON Schema `$id` values from SchemaStore URLs to raw GitHub hosting URLs since schemas are externally hosted (closes #19)
- Replace hand-rolled Ajv validation with xdg-effect's `JsonSchemaValidator` service (`generateMany` -> `validateMany` -> `writeMany` pipeline)
- Fix invalid `x-tombi-table-keys-order` annotation on `RulesetSchema` union node
- Upgrade xdg-effect from 0.3.1 to 0.3.3

## Test plan

- [x] `pnpm run test` passes (all tests green)
- [x] `pnpm --filter reposets generate:json-schema` succeeds with strict validation
- [x] Generated schemas have correct `$id` URLs pointing to raw GitHub
- [x] `$id` appears as second key after `$schema` (xdg-effect 0.3.2+ ordering)
- [x] Changeset validated with `savvy-changesets validate-file`

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>