### PR TITLE
feat(cli): advanced security and CodeQL default setup sync

### DIFF
--- a/.changeset/advanced-security-sync.md
+++ b/.changeset/advanced-security-sync.md
@@ -1,0 +1,80 @@
+---
+"reposets": minor
+---
+
+## Features
+
+### Advanced Security configuration
+
+Sync GitHub Advanced Security settings, vulnerability alert toggles, and CodeQL default setup across reposets. The feature spans three distinct GitHub API surfaces, each with its own config shape.
+
+#### Nested `security_and_analysis` block
+
+Configure secret scanning, push protection, AI detection, non-provider patterns, delegated dismissal/bypass, and Dependabot security updates inside any settings group. Folded into the same `PATCH /repos/{owner}/{repo}` call already used for repository settings.
+
+```toml
+[settings.oss-defaults.security_and_analysis]
+secret_scanning = "enabled"
+secret_scanning_push_protection = "enabled"
+secret_scanning_ai_detection = "enabled"
+dependabot_security_updates = "enabled"
+
+[[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
+team = "security-team"
+mode = "ALWAYS"
+```
+
+Team slugs in `delegated_bypass_reviewers` are resolved to numeric reviewer IDs at sync time. Org-only fields are silently skipped on personal repos with a warning.
+
+#### Top-level `[security.*]` groups
+
+Toggle vulnerability alerts, automated security fixes, and private vulnerability reporting. Each maps to a dedicated `PUT`/`DELETE` endpoint and is diffed against current state — only changed values are applied.
+
+```toml
+[security.oss-defaults]
+vulnerability_alerts = true
+automated_security_fixes = true
+private_vulnerability_reporting = true
+```
+
+#### Top-level `[code_scanning.*]` groups
+
+Configure CodeQL default setup with full enum-validated state, languages, query suite, threat model, and runner. Configured languages are filtered against repository languages detected by GitHub; mismatches are warned and dropped.
+
+```toml
+[code_scanning.oss-defaults]
+state = "configured"
+languages = ["javascript-typescript", "python"]
+query_suite = "extended"
+threat_model = "remote"
+```
+
+Reference both new section types from any group:
+
+```toml
+[groups.personal]
+repos = ["repo-a", "repo-b"]
+security = ["oss-defaults"]
+code_scanning = ["oss-defaults"]
+```
+
+### License and ownership awareness
+
+Schema accepts every field regardless of repository visibility or GHAS license. At sync time, reposets:
+
+* Detects ownership type once per group via the cached `getOwnerType` API
+* Drops org-only fields (`secret_scanning_delegated_alert_dismissal`, `secret_scanning_delegated_bypass`, `delegated_bypass_reviewers`) on personal repos with a logged warning
+* Logs warnings on `422`/`403`/`404` errors from GHAS-licensed fields without failing the run
+* Filters configured CodeQL languages to those GitHub detects in the repo and warns about the rest
+
+### CLI updates
+
+* `list` summarises `security` and `code_scanning` group references per group
+* `validate` rejects unknown `security`/`code_scanning` references with the same error format as other refs
+* `doctor` documents the additional fine-grained token permissions required (Code scanning alerts, Dependabot alerts, Secret scanning alerts, Members:read)
+* `init` template includes commented-out advanced security examples
+
+## Documentation
+
+* New JSON schema sections for `security_and_analysis` (nested in settings groups), `[security.*]`, and `[code_scanning.*]` with `(GHAS-licensed)` and `(org-only)` annotations on relevant fields
+* CodeQL default-setup language enum constrained to GitHub's nine accepted values; Rust support deferred until GitHub adds it

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -94,7 +94,7 @@ Layers are composed at two levels:
     filter configured CodeQL languages by what `listRepoLanguages` detects
     (mapped through `REPO_LANG_TO_CODEQL`); warn (don't fail) on
     non-detected entries; PATCH the default-setup endpoint (`202 Accepted`,
-    fire-and-forget by default; verbose mode polls until applied)
+    sent without polling for completion)
 12. Environments synced before secrets/variables (environments must exist
     before scoped resources can be attached)
 13. GitHubClient applies remaining changes per repo: environments, secrets
@@ -125,7 +125,7 @@ All errors are `Data.TaggedError` subclasses:
 Each service has Live and Test layer implementations:
 
 - `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 28 service methods including environment, security feature, code
+  all 30 service methods including environment, security feature, code
   scanning, and team-resolver operations)
 - `OnePasswordClientTest(stubs)` - returns deterministic values
 - `makeConfigFilesLive` - used directly in tests (builds xdg-effect

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -3,15 +3,16 @@ module: reposets
 title: Architecture
 status: current
 completeness: 95
-last-synced: 2026-04-23
+last-synced: 2026-04-27
 ---
 
 ## Overview
 
 reposets is an Effect-based CLI for syncing GitHub repository settings,
-secrets, variables, rulesets, and deployment environments across personal
-repos. Config files serve as distributable templates; environment-specific
-values are resolved from credential profiles at runtime.
+secrets, variables, rulesets, deployment environments, repository security
+features, and CodeQL default setup across personal and organization repos.
+Config files serve as distributable templates; environment-specific values
+are resolved from credential profiles at runtime.
 
 ## Service Graph
 
@@ -73,14 +74,37 @@ Layers are composed at two levels:
    (`targets`, `pull_requests`, `status_checks`, boolean flags) normalized
    via `normalizeRuleset()` into API-compatible format; `{ resolved }`
    references substituted from the credential map with type coercion
-8. Environments synced before secrets/variables (environments must exist
-   before scoped resources can be attached)
-9. GitHubClient applies changes per repo: environments, secrets by scope
-   (actions/dependabot/codespaces/environments), variables by scope
-   (actions/environments), settings (REST + GraphQL mutation), rulesets
-10. Cleanup phase deletes undeclared resources per scope, respecting
-    preserve lists and per-group cleanup configuration
-11. SyncLogger emits tiered output throughout (info summaries, verbose
+8. Owner type detected once per group via `GitHubClient.getOwnerType()`;
+   used downstream to strip org-only fields (e.g., `allow_forking` from
+   settings, and `secret_scanning_delegated_*` /
+   `delegated_bypass_reviewers` from `security_and_analysis`) on personal
+   accounts
+9. Settings stage: merged settings (REST `repos.update`) plus a folded
+   `security_and_analysis` block (transformed via
+   `transformSecurityAndAnalysis()`) plus GraphQL mutation for
+   `has_sponsorships` / `has_pull_requests`. Org-owned repos resolve
+   `delegated_bypass_reviewers` team slugs to numeric `reviewer_id`s via
+   `GitHubClient.resolveTeamId()` (cached per `org:slug`) before the PATCH
+10. Security features stage (between settings and secrets, implemented
+    inline in `SyncEngine.syncAll`): for each of `vulnerability_alerts`,
+    `automated_security_fixes`, and `private_vulnerability_reporting`,
+    probe current state via the corresponding `getXxx` method, compare to
+    the merged desired value, and PUT/DELETE only on diff
+11. Code scanning stage (after the security features stage, also inline):
+    filter configured CodeQL languages by what `listRepoLanguages` detects
+    (mapped through `REPO_LANG_TO_CODEQL`); warn (don't fail) on
+    non-detected entries; PATCH the default-setup endpoint (`202 Accepted`,
+    fire-and-forget by default; verbose mode polls until applied)
+12. Environments synced before secrets/variables (environments must exist
+    before scoped resources can be attached)
+13. GitHubClient applies remaining changes per repo: environments, secrets
+    by scope (actions/dependabot/codespaces/environments), variables by
+    scope (actions/environments), rulesets
+14. Cleanup phase deletes undeclared resources per scope, respecting
+    preserve lists and per-group cleanup configuration. (Security feature
+    toggles and code scanning default setup follow "leave alone if
+    omitted" semantics and have no `cleanup` scope of their own.)
+15. SyncLogger emits tiered output throughout (info summaries, verbose
     per-operation, debug with source details)
 
 ## Error Model
@@ -101,7 +125,8 @@ All errors are `Data.TaggedError` subclasses:
 Each service has Live and Test layer implementations:
 
 - `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 20 service methods including environment operations)
+  all 28 service methods including environment, security feature, code
+  scanning, and team-resolver operations)
 - `OnePasswordClientTest(stubs)` - returns deterministic values
 - `makeConfigFilesLive` - used directly in tests (builds xdg-effect
   resolver chains for config + credentials)

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -125,7 +125,7 @@ All errors are `Data.TaggedError` subclasses:
 Each service has Live and Test layer implementations:
 
 - `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 29 service methods including environment, security feature, code
+  all 30 service methods including environment, security feature, code
   scanning, and team-resolver operations)
 - `OnePasswordClientTest(stubs)` - returns deterministic values
 - `makeConfigFilesLive` - used directly in tests (builds xdg-effect

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -125,7 +125,7 @@ All errors are `Data.TaggedError` subclasses:
 Each service has Live and Test layer implementations:
 
 - `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 30 service methods including environment, security feature, code
+  all 29 service methods including environment, security feature, code
   scanning, and team-resolver operations)
 - `OnePasswordClientTest(stubs)` - returns deterministic values
 - `makeConfigFilesLive` - used directly in tests (builds xdg-effect

--- a/.claude/design/reposets/config-format.md
+++ b/.claude/design/reposets/config-format.md
@@ -3,14 +3,14 @@ module: reposets
 title: Configuration Format
 status: current
 completeness: 95
-last-synced: 2026-04-23
+last-synced: 2026-04-27
 ---
 
 ## Files
 
 | File | Purpose | Location |
 | :--- | :------ | :------- |
-| `reposets.config.toml` | Groups, settings, environments, secrets, variables, rulesets, cleanup | XDG or project-local |
+| `reposets.config.toml` | Groups, settings, environments, secrets, variables, rulesets, security, code_scanning, cleanup | XDG or project-local |
 | `reposets.credentials.toml` | Named credential profiles with resolve sections (gitignored) | XDG config dir |
 
 ## Config Path Resolution
@@ -42,6 +42,21 @@ log_level = "info"
 has_wiki = false
 has_discussions = false
 delete_branch_on_merge = true
+
+[settings.default.security_and_analysis]
+secret_scanning = "enabled"
+secret_scanning_push_protection = "enabled"
+dependabot_security_updates = "enabled"
+
+[security.baseline]
+vulnerability_alerts = true
+automated_security_fixes = true
+private_vulnerability_reporting = true
+
+[code_scanning.baseline]
+state = "configured"
+languages = ["javascript-typescript", "python"]
+query_suite = "extended"
 
 [environments.staging]
 wait_timer = 0
@@ -95,6 +110,8 @@ environments = ["staging", "production"]
 secrets = { actions = ["deploy", "api"], dependabot = ["deploy"], environments = { production = ["api"] } }
 variables = { actions = ["turbo", "bot"], environments = { staging = ["turbo"] } }
 rulesets = ["branch-protection"]
+security = ["baseline"]
+code_scanning = ["baseline"]
 
 [groups.my-projects.cleanup]
 rulesets = true
@@ -202,6 +219,25 @@ Variables use a `VariableScopes` object with two fields:
 - `environments` - record mapping environment names to arrays of variable
   group names for environment-scoped variables
 
+## Group Reference Fields
+
+`[groups.<name>]` accepts the following reference arrays, each pointing
+into the matching top-level table:
+
+- `settings: string[]` -> `[settings.*]`
+- `rulesets: string[]` -> `[rulesets.*]`
+- `environments: string[]` -> `[environments.*]`
+- `security: string[]` -> `[security.*]` (new)
+- `code_scanning: string[]` -> `[code_scanning.*]` (new)
+
+Plus the `secrets: SecretScopes` and `variables: VariableScopes` structs
+described above.
+
+The `validateConfigRefs` callback (registered as the
+`ReposetsConfigFile` validator) collects errors across every reference
+array, including the new `security` and `code_scanning` arrays, and
+reports all unknown references in a single `ConfigError`.
+
 ## Settings Schema
 
 The `SettingsGroupSchema` is a typed struct with 20+ known fields and
@@ -222,6 +258,117 @@ fields include:
 
 Fields `has_sponsorships` and `has_pull_requests` are synced via GraphQL
 `updateRepository` mutation (not available in REST API).
+
+### `security_and_analysis` Block
+
+`SettingsGroupSchema` allows a nested `security_and_analysis` table whose
+fields ride along with the same `PATCH /repos/{owner}/{repo}` call as the
+rest of the settings block (see `transformSecurityAndAnalysis()` in
+`GitHubClient`). Status fields take `"enabled" | "disabled"`:
+
+- `advanced_security` (GHAS-licensed) - master GHAS toggle
+- `code_security` (GHAS-licensed)
+- `secret_scanning`
+- `secret_scanning_push_protection`
+- `secret_scanning_ai_detection` (GHAS-licensed)
+- `secret_scanning_non_provider_patterns` (GHAS-licensed)
+- `secret_scanning_delegated_alert_dismissal` (org-only)
+- `secret_scanning_delegated_bypass` (org-only)
+- `dependabot_security_updates`
+
+Plus an optional `delegated_bypass_reviewers` array (org-only). Each
+entry is a discriminated union: exactly one of `team` (slug) or `role`
+(role name), with an optional `mode = "ALWAYS" | "EXEMPT"`. Team slugs
+are resolved to numeric `reviewer_id`s via `GitHubClient.resolveTeamId()`
+at sync time; role entries are passed through with `reviewer_type =
+"ROLE"`.
+
+```toml
+[settings.oss-defaults.security_and_analysis]
+secret_scanning = "enabled"
+secret_scanning_push_protection = "enabled"
+secret_scanning_ai_detection = "enabled"
+dependabot_security_updates = "enabled"
+
+[[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
+team = "security-team"
+mode = "ALWAYS"
+
+[[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
+role = "admin"
+mode = "EXEMPT"
+```
+
+GHAS-licensed fields generally succeed on public repos and fail
+(HTTP 422) on unlicensed private repos; org-only fields are silently
+stripped from the merged block on personal accounts before the PATCH.
+Omitting any field means "leave alone" - no separate cleanup scope.
+
+## Security Group Schema
+
+Top-level `[security.<name>]` groups configure repository security
+features that have dedicated PUT/DELETE endpoints. Each field is an
+optional boolean; omitted fields are "leave alone".
+
+- `vulnerability_alerts` - Dependabot vulnerability alerts
+  (`PUT`/`DELETE /repos/{o}/{r}/vulnerability-alerts`)
+- `automated_security_fixes` - Dependabot security PRs
+  (`PUT`/`DELETE /repos/{o}/{r}/automated-security-fixes`); requires
+  `vulnerability_alerts` to also be enabled
+- `private_vulnerability_reporting` - private vulnerability reporting
+  inbox (`PUT`/`DELETE /repos/{o}/{r}/private-vulnerability-reporting`)
+
+```toml
+[security.baseline]
+vulnerability_alerts = true
+automated_security_fixes = true
+private_vulnerability_reporting = true
+```
+
+Groups reference security groups via the `security: string[]` field on
+`[groups.<name>]`. Multiple references are merged last-write-wins by
+`mergeSecurityGroups()` at sync time; the SyncEngine probes current
+state via the matching `getXxx` GitHubClient method and only PUTs/DELETEs
+on diff.
+
+## Code Scanning Group Schema
+
+Top-level `[code_scanning.<name>]` groups configure the
+CodeQL default-setup feature, applied via
+`PATCH /repos/{o}/{r}/code-scanning/default-setup`. Fields:
+
+- `state` - `"configured" | "not-configured"`
+- `languages` - array of CodeQL default-setup language literals (see
+  enum below); languages not detected in the repository are filtered
+  out at sync time with a warning rather than failing the run
+- `query_suite` - `"default" | "extended"`
+- `threat_model` - `"remote" | "remote_and_local"`
+- `runner_type` - `"standard" | "labeled"`
+- `runner_label` - free-form runner label string; required when
+  `runner_type = "labeled"`
+
+```toml
+[code_scanning.baseline]
+state = "configured"
+languages = ["javascript-typescript", "python"]
+query_suite = "extended"
+threat_model = "remote"
+runner_type = "standard"
+```
+
+Default-setup language enum (9 values):
+`actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`,
+`javascript-typescript`, `python`, `ruby`, `swift`.
+
+This is intentionally narrower than the CodeQL analyzer language list -
+Rust is supported by CodeQL itself but not by default setup as of this
+writing. Add to the literal when GitHub widens default-setup support.
+
+Groups reference code scanning groups via the `code_scanning: string[]`
+field on `[groups.<name>]`. Multiple references are merged last-write-wins
+by `mergeCodeScanningGroups()`. The PATCH endpoint returns
+`202 Accepted`; reposets fires-and-forgets by default and polls in
+verbose mode.
 
 ## Cleanup Configuration
 

--- a/.claude/design/reposets/config-format.md
+++ b/.claude/design/reposets/config-format.md
@@ -277,11 +277,15 @@ rest of the settings block (see `transformSecurityAndAnalysis()` in
 - `dependabot_security_updates`
 
 Plus an optional `delegated_bypass_reviewers` array (org-only). Each
-entry is a discriminated union: exactly one of `team` (slug) or `role`
-(role name), with an optional `mode = "ALWAYS" | "EXEMPT"`. Team slugs
-are resolved to numeric `reviewer_id`s via `GitHubClient.resolveTeamId()`
-at sync time; role entries are passed through with `reviewer_type =
-"ROLE"`.
+entry is a discriminated union: exactly one of `team` (a GitHub team
+slug) or `role` (an organization role name from
+`GET /orgs/{org}/organization-roles` such as `all_repo_admin` or a
+custom role like `security_manager`), with an optional
+`mode = "ALWAYS" | "EXEMPT"`. Both forms are resolved to numeric
+`reviewer_id`s at sync time -- team slugs via
+`GitHubClient.resolveTeamId()` and role names via
+`GitHubClient.resolveRoleId()`. Role IDs are per-org even for predefined
+roles, so the resolver must consult the live API per (org, role) pair.
 
 ```toml
 [settings.oss-defaults.security_and_analysis]

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -156,7 +156,7 @@ return booleans normalized from the underlying API responses.
 - `updateCodeScanningDefaultSetup(owner, repo, config): void` -
   `PATCH /repos/{o}/{r}/code-scanning/default-setup`. The endpoint
   responds `202 Accepted` and applies asynchronously; the SyncEngine
-  fires-and-forgets by default and polls in verbose mode
+  sends the request without polling for completion
 
 ### Helper Methods
 

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -88,7 +88,7 @@ for test capture. Test layer uses `logLevel: "silent"` to suppress output.
 
 ## GitHubClient
 
-Wraps Octokit with typed methods for all GitHub API operations. 29 methods
+Wraps Octokit with typed methods for all GitHub API operations. 30 methods
 organized into five domains: repo-level resources, environments,
 environment-scoped resources, repository security features, and CodeQL
 default setup.
@@ -165,6 +165,16 @@ return booleans normalized from the underlying API responses.
   `org:slug` for the lifetime of the GitHubClient instance. Used to map
   `delegated_bypass_reviewers[].team` slugs to API-shaped
   `{ reviewer_id, reviewer_type: "TEAM" }` entries during settings sync
+- `resolveRoleId(org, name): number` - looks up
+  `GET /orgs/{org}/organization-roles`, scans the returned roles for a
+  match on the `name` field, and caches the numeric role id keyed by
+  `org:name`. Used to map `delegated_bypass_reviewers[].role` names to
+  API-shaped `{ reviewer_id, reviewer_type: "ROLE" }` entries. Role IDs
+  are per-org even for predefined roles, so the resolution must happen
+  against the live API for every (org, role) pair the first time they
+  appear; failures (unknown role name) are surfaced as `GitHubApiError`
+  and trigger the standard catch-and-warn path so the rest of the sync
+  proceeds
 
 ### `transformSecurityAndAnalysis` helper
 
@@ -215,7 +225,7 @@ appropriate Octokit API namespace. The `SecretScope` type is
 Live: `GitHubClientLive(token)` creates an Octokit instance per token; the
 `teamIdCache` (Map<string, number> keyed by `org:slug`) is per-instance.
 Test: `GitHubClientTest()` returns `{ layer, calls() }` recorder covering
-all 29 methods.
+all 30 methods.
 
 ## SyncEngine
 
@@ -250,8 +260,11 @@ Flow per group:
     `secret_scanning_delegated_bypass`, `delegated_bypass_reviewers`) on
     personal accounts; on org accounts, resolve each
     `delegated_bypass_reviewers[].team` slug to a numeric `reviewer_id`
-    via `GitHubClient.resolveTeamId()` and rewrite `{ role: ... }` entries
-    to `{ reviewer_id: <role-string>, reviewer_type: "ROLE" }`. Inject the
+    via `GitHubClient.resolveTeamId()` and each `delegated_bypass_reviewers[].role`
+    name to a numeric role id via `GitHubClient.resolveRoleId()`. Both
+    resolvers cache results per `org:slug` and `org:name` for the
+    lifetime of the GitHubClient instance. Resolved entries are rewritten
+    to `{ reviewer_id, reviewer_type: "TEAM" | "ROLE" }`. Inject the
     resolved block back into `mergedSettings` under
     `security_and_analysis` so it rides along with the existing
     `syncSettings` PATCH (where `transformSecurityAndAnalysis()` reshapes

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -3,7 +3,7 @@ module: reposets
 title: Effect Services
 status: current
 completeness: 95
-last-synced: 2026-04-23
+last-synced: 2026-04-27
 ---
 
 ## ConfigFiles
@@ -88,9 +88,10 @@ for test capture. Test layer uses `logLevel: "silent"` to suppress output.
 
 ## GitHubClient
 
-Wraps Octokit with typed methods for all GitHub API operations. 20 methods
-organized into four domains: repo-level resources, environments, and
-environment-scoped resources.
+Wraps Octokit with typed methods for all GitHub API operations. 30 methods
+organized into five domains: repo-level resources, environments,
+environment-scoped resources, repository security features, and CodeQL
+default setup.
 
 ### Repo-Level Methods
 
@@ -100,7 +101,11 @@ environment-scoped resources.
 - `syncVariable(owner, repo, name, value)` - create or update
 - `syncSettings(owner, repo, settings)` - REST `repos.update` for standard
   fields; GraphQL `updateRepository` mutation for `has_sponsorships` and
-  `has_pull_requests` (mapped via `GRAPHQL_SETTINGS` constant)
+  `has_pull_requests` (mapped via `GRAPHQL_SETTINGS` constant). The
+  `security_and_analysis` field is folded into the REST PATCH body by the
+  SyncEngine via `transformSecurityAndAnalysis()` (status fields wrapped
+  as `{ status: "enabled" | "disabled" }`; `delegated_bypass_reviewers`
+  rewritten under `secret_scanning_delegated_bypass_options.reviewers`)
 - `syncRuleset(owner, repo, name, payload)` - create or update by name;
   accepts `Ruleset` schema type directly
 - `listSecrets/listVariables/listRulesets` - query existing resources
@@ -119,6 +124,75 @@ environment-scoped resources.
   resources
 - `deleteEnvironment/deleteEnvironmentSecret/deleteEnvironmentVariable` -
   cleanup operations
+
+### Repository Security Methods
+
+State-probe + toggle pairs for each of the three dedicated PUT/DELETE
+endpoints. Probes are used by the SyncEngine's security-features stage to
+diff current vs. desired state and only call PUT/DELETE on change. All
+return booleans normalized from the underlying API responses.
+
+- `getVulnerabilityAlerts(owner, repo): boolean` -
+  `GET /repos/{o}/{r}/vulnerability-alerts` (404 -> `false`,
+  204 -> `true`)
+- `setVulnerabilityAlerts(owner, repo, enabled): void` -
+  `PUT` (enabled) / `DELETE` (disabled) on the same path
+- `getAutomatedSecurityFixes(owner, repo): boolean` -
+  `GET /repos/{o}/{r}/automated-security-fixes`; reads `data.enabled`
+- `setAutomatedSecurityFixes(owner, repo, enabled): void` -
+  `PUT`/`DELETE /repos/{o}/{r}/automated-security-fixes`
+- `getPrivateVulnerabilityReporting(owner, repo): boolean` -
+  `GET /repos/{o}/{r}/private-vulnerability-reporting`; reads
+  `data.enabled`
+- `setPrivateVulnerabilityReporting(owner, repo, enabled): void` -
+  `PUT`/`DELETE /repos/{o}/{r}/private-vulnerability-reporting`
+
+### Code Scanning Methods
+
+- `getCodeScanningDefaultSetup(owner, repo): CodeScanningDefaultSetup` -
+  `GET /repos/{o}/{r}/code-scanning/default-setup`. Returns the current
+  setup (state, languages, query_suite, threat_model, runner_type,
+  runner_label)
+- `updateCodeScanningDefaultSetup(owner, repo, config): void` -
+  `PATCH /repos/{o}/{r}/code-scanning/default-setup`. The endpoint
+  responds `202 Accepted` and applies asynchronously; the SyncEngine
+  fires-and-forgets by default and polls in verbose mode
+
+### Helper Methods
+
+- `listRepoLanguages(owner, repo): string[]` - thin wrapper around
+  `octokit.repos.listLanguages` returning the language-name keys; used to
+  filter configured CodeQL languages against what GitHub detects in the
+  repo
+- `resolveTeamId(org, slug): number` - looks up
+  `GET /orgs/{org}/teams/{slug}` and caches the numeric team id keyed by
+  `org:slug` for the lifetime of the GitHubClient instance. Used to map
+  `delegated_bypass_reviewers[].team` slugs to API-shaped
+  `{ reviewer_id, reviewer_type: "TEAM" }` entries during settings sync
+
+### `transformSecurityAndAnalysis` helper
+
+Exported alongside the service interface for direct unit testing.
+`transformSecurityAndAnalysis(value)` translates the user-facing
+`security_and_analysis` config block into the shape the GitHub REST API
+expects on `PATCH /repos/{o}/{r}`:
+
+- Each known status field (members of the `SAA_STATUS_FIELDS` set:
+  `advanced_security`, `code_security`, `secret_scanning`,
+  `secret_scanning_push_protection`,
+  `secret_scanning_ai_detection`,
+  `secret_scanning_non_provider_patterns`,
+  `secret_scanning_delegated_alert_dismissal`,
+  `secret_scanning_delegated_bypass`,
+  `dependabot_security_updates`) wraps its `"enabled" | "disabled"`
+  value as `{ status: "..." }`
+- `delegated_bypass_reviewers` is rewritten under
+  `secret_scanning_delegated_bypass_options.reviewers` (entries are
+  expected to already carry numeric `reviewer_id` and `reviewer_type`;
+  team-slug resolution happens in the SyncEngine before calling the
+  transform)
+- Returns `undefined` when the result is empty so callers can omit the
+  field cleanly from the PATCH body
 
 ### GraphQL Settings
 
@@ -142,9 +216,10 @@ Secret scopes: `actions`, `dependabot`, `codespaces` - each routes to the
 appropriate Octokit API namespace. The `SecretScope` type is
 `"actions" | "dependabot" | "codespaces"`.
 
-Live: `GitHubClientLive(token)` creates an Octokit instance per token.
+Live: `GitHubClientLive(token)` creates an Octokit instance per token; the
+`teamIdCache` (Map<string, number> keyed by `org:slug`) is per-instance.
 Test: `GitHubClientTest()` returns `{ layer, calls() }` recorder covering
-all 20 methods.
+all 30 methods.
 
 ## SyncEngine
 
@@ -159,27 +234,56 @@ Flow per group:
 2. Resolve credential profile (explicit or implicit single profile)
 3. Resolve all credential labels via `CredentialResolver.resolveAll()`
    into a flat `Map<string, string>`
-4. Resolve secret groups by scope: `actions`, `dependabot`, `codespaces`
+4. Detect ownership type via `GitHubClient.getOwnerType()` (defaults to
+   `"User"` on API failure); used to strip org-only fields
+5. Resolve secret groups by scope: `actions`, `dependabot`, `codespaces`
    each get their own resolved map
-5. Resolve variable groups from `variables.actions` references
-6. Collect rulesets from config; normalize shorthands via
+6. Resolve variable groups from `variables.actions` references
+7. Collect rulesets from config; normalize shorthands via
    `normalizeRuleset()`; substitute `{ resolved }` references with values
    from the credential map, coercing to integers where needed
-7. Resolve environment references from `group.environments` array
-8. Resolve environment-scoped secrets from `group.secrets.environments`
+8. Resolve environment references from `group.environments` array
+9. Resolve environment-scoped secrets from `group.secrets.environments`
    mapping (env name -> secret group refs)
-9. Resolve environment-scoped variables from `group.variables.environments`
-   mapping (env name -> variable group refs)
-10. Compute per-group cleanup config (no global merge; defaults to all-off)
-11. For each repo (skipping mutations in dry-run):
-    - Sync settings (merged from referenced setting groups)
+10. Resolve environment-scoped variables from `group.variables.environments`
+    mapping (env name -> variable group refs)
+11. Merge settings from referenced setting groups; pull each group's
+    `security_and_analysis` block aside and merge those separately via
+    `mergeSecurityAndAnalysis()` (last-write-wins). Strip `ORG_ONLY_SAA_FIELDS`
+    (`secret_scanning_delegated_alert_dismissal`,
+    `secret_scanning_delegated_bypass`, `delegated_bypass_reviewers`) on
+    personal accounts; on org accounts, resolve each
+    `delegated_bypass_reviewers[].team` slug to a numeric `reviewer_id`
+    via `GitHubClient.resolveTeamId()` and rewrite `{ role: ... }` entries
+    to `{ reviewer_id: <role-string>, reviewer_type: "ROLE" }`. Inject the
+    resolved block back into `mergedSettings` under
+    `security_and_analysis` so it rides along with the existing
+    `syncSettings` PATCH (where `transformSecurityAndAnalysis()` reshapes
+    it for the API)
+12. Merge `[security.*]` groups via `mergeSecurityGroups()` and
+    `[code_scanning.*]` groups via `mergeCodeScanningGroups()` -
+    last-write-wins across all references; missing keys remain undefined
+    so they're "leave alone" at sync time
+13. Compute per-group cleanup config (no global merge; defaults to all-off)
+14. For each repo (skipping mutations in dry-run):
+    - Sync settings (merged settings + folded `security_and_analysis`)
+    - Security features stage (inline): for each of `vulnerability_alerts`,
+      `automated_security_fixes`, `private_vulnerability_reporting`, probe
+      current state via the corresponding `getXxx` method and call PUT or
+      DELETE only when the desired value differs
+    - Code scanning stage (inline): filter merged
+      `code_scanning.languages[]` against languages detected by
+      `listRepoLanguages` (mapped through the `REPO_LANG_TO_CODEQL`
+      table; `actions` always passes through), then call
+      `updateCodeScanningDefaultSetup`. Languages not detected emit a
+      `skip` log line at info/verbose levels rather than failing
     - Sync environments (must exist before scoped resources)
     - Sync secrets by scope (actions/dependabot/codespaces)
     - Sync environment secrets per environment
     - Sync variables (actions scope)
     - Sync environment variables per environment
     - Sync rulesets (fully resolved/normalized `Ruleset` objects)
-12. Cleanup phase per scope: delete undeclared resources respecting
+15. Cleanup phase per scope: delete undeclared resources respecting
     preserve lists from the three-way `CleanupScope` union
     - Actions/dependabot/codespaces secrets
     - Environment secrets (per environment)
@@ -189,3 +293,42 @@ Flow per group:
     - Environments
 
 Options: `dryRun`, `noCleanup`, `groupFilter`, `repoFilter`, `configDir`
+
+### Merge Helpers
+
+Three internal helpers implement last-write-wins merging across reference
+lists in declaration order:
+
+- `mergeSecurityAndAnalysis(blocks)` - merges
+  `SecurityAndAnalysis | undefined` blocks pulled from each referenced
+  setting group; returns `undefined` when no block contributed any keys
+  so the entire `security_and_analysis` field can be omitted from the
+  PATCH
+- `mergeSecurityGroups(groups)` - merges `SecurityGroup` toggles from
+  `[security.*]` references; only keeps boolean values, so partial
+  configurations cleanly carry through
+- `mergeCodeScanningGroups(groups)` - merges `CodeScanningGroup` configs
+  from `[code_scanning.*]` references; preserves any defined keys
+  (state/languages/query_suite/etc.) and lets undefined keys fall through
+  as "leave alone"
+
+### Language Mapping
+
+`REPO_LANG_TO_CODEQL` (defined at the top of `SyncEngine.ts`) maps repo
+language names (as returned by `octokit.repos.listLanguages`) onto the
+default-setup language enum:
+
+- `JavaScript`, `TypeScript` -> `javascript-typescript`
+- `C`, `C++` -> `c-cpp`
+- `C#` -> `csharp`
+- `Go` -> `go`
+- `Java`, `Kotlin` -> `java-kotlin`
+- `Python` -> `python`
+- `Ruby` -> `ruby`
+- `Swift` -> `swift`
+
+Languages outside the map are dropped from the detected set; the
+code scanning stage uses this set to decide whether a configured
+CodeQL language should be passed through or skipped with a warning. The
+`actions` pseudo-language always passes through unchanged because it
+isn't a repo language at all.

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -88,7 +88,7 @@ for test capture. Test layer uses `logLevel: "silent"` to suppress output.
 
 ## GitHubClient
 
-Wraps Octokit with typed methods for all GitHub API operations. 30 methods
+Wraps Octokit with typed methods for all GitHub API operations. 29 methods
 organized into five domains: repo-level resources, environments,
 environment-scoped resources, repository security features, and CodeQL
 default setup.
@@ -149,10 +149,6 @@ return booleans normalized from the underlying API responses.
 
 ### Code Scanning Methods
 
-- `getCodeScanningDefaultSetup(owner, repo): CodeScanningDefaultSetup` -
-  `GET /repos/{o}/{r}/code-scanning/default-setup`. Returns the current
-  setup (state, languages, query_suite, threat_model, runner_type,
-  runner_label)
 - `updateCodeScanningDefaultSetup(owner, repo, config): void` -
   `PATCH /repos/{o}/{r}/code-scanning/default-setup`. The endpoint
   responds `202 Accepted` and applies asynchronously; the SyncEngine
@@ -219,7 +215,7 @@ appropriate Octokit API namespace. The `SecretScope` type is
 Live: `GitHubClientLive(token)` creates an Octokit instance per token; the
 `teamIdCache` (Map<string, number> keyed by `org:slug`) is per-instance.
 Test: `GitHubClientTest()` returns `{ layer, calls() }` recorder covering
-all 30 methods.
+all 29 methods.
 
 ## SyncEngine
 
@@ -263,7 +259,12 @@ Flow per group:
 12. Merge `[security.*]` groups via `mergeSecurityGroups()` and
     `[code_scanning.*]` groups via `mergeCodeScanningGroups()` -
     last-write-wins across all references; missing keys remain undefined
-    so they're "leave alone" at sync time
+    so they're "leave alone" at sync time. After merging, detect the
+    cross-field contradiction (`automated_security_fixes = true` paired
+    with `vulnerability_alerts = false`) that `SecurityGroupSchema`
+    rejects in a single group but that merging can recreate; if found,
+    the security stage logs an error and is skipped for the affected
+    repos rather than letting GitHub return 422
 13. Compute per-group cleanup config (no global merge; defaults to all-off)
 14. For each repo (skipping mutations in dry-run):
     - Sync settings (merged settings + folded `security_and_analysis`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ at `package/` (workspace name: `reposets`).
 ```text
 package/                   # reposets CLI package
 package/src/cli/           # CLI entrypoint and commands
-package/src/services/      # Effect services (6 services, 30 GitHubClient methods)
+package/src/services/      # Effect services (6 services, 29 GitHubClient methods)
 package/src/schemas/       # Effect Schema definitions (config, credentials, environment, ruleset) + JSON schema generation
 package/src/lib/           # Utilities (XDG paths, config resolution, crypto)
 package/__test__/          # Tests mirroring src/ structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ at `package/` (workspace name: `reposets`).
 ```text
 package/                   # reposets CLI package
 package/src/cli/           # CLI entrypoint and commands
-package/src/services/      # Effect services (6 services, 20 GitHubClient methods)
+package/src/services/      # Effect services (6 services, 30 GitHubClient methods)
 package/src/schemas/       # Effect Schema definitions (config, credentials, environment, ruleset) + JSON schema generation
 package/src/lib/           # Utilities (XDG paths, config resolution, crypto)
 package/__test__/          # Tests mirroring src/ structure
@@ -117,13 +117,23 @@ Six services compose the sync pipeline:
 - `CredentialResolver` — Resolves named values from credential profile
   `[resolve]` sections (value, file, and op sub-groups)
 - `OnePasswordClient` — Wraps `@1password/sdk` for 1Password secret references
-- `GitHubClient` — Octokit wrapper (20 methods, including `getOwnerType`);
-  handles settings (REST + GraphQL mutation), secrets by scope
+- `GitHubClient` — Octokit wrapper (30 methods, including `getOwnerType`);
+  handles settings (REST + GraphQL mutation, with `security_and_analysis`
+  folded in via `transformSecurityAndAnalysis`), secrets by scope
   (actions/dependabot/codespaces/environments), variables by scope
-  (actions/environments), rulesets, and deployment environments
-- `SyncEngine` — Orchestrates the full sync lifecycle: environments synced
-  before secrets/variables so scoped resources can attach; per-group cleanup
-  using three-way `CleanupScope` union
+  (actions/environments), rulesets, deployment environments, repository
+  security toggles (vulnerability_alerts, automated_security_fixes,
+  private_vulnerability_reporting), CodeQL default setup, and team-slug
+  resolution (cached per `org:slug`)
+- `SyncEngine` — Orchestrates the full sync lifecycle. Order: settings
+  (with merged `security_and_analysis` and resolved reviewer IDs) →
+  security features (diff and apply vulnerability_alerts/
+  automated_security_fixes/private_vulnerability_reporting via dedicated
+  PUT/DELETE endpoints) → code scanning (filter configured CodeQL
+  languages by `listRepoLanguages` and PATCH default-setup) →
+  environments → secrets → variables → rulesets → cleanup. Per-group
+  cleanup uses the three-way `CleanupScope` union (security and
+  code_scanning have no cleanup — omitted = leave alone)
 - `SyncLogger` — Tiered output (silent/info/verbose/debug) with dry-run
   awareness; all sync output flows through this service
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ at `package/` (workspace name: `reposets`).
 ```text
 package/                   # reposets CLI package
 package/src/cli/           # CLI entrypoint and commands
-package/src/services/      # Effect services (6 services, 29 GitHubClient methods)
+package/src/services/      # Effect services (6 services, 30 GitHubClient methods)
 package/src/schemas/       # Effect Schema definitions (config, credentials, environment, ruleset) + JSON schema generation
 package/src/lib/           # Utilities (XDG paths, config resolution, crypto)
 package/__test__/          # Tests mirroring src/ structure

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Ruleset shorthand syntax** — Define branch and tag rulesets with compact inline syntax for pull request rules, status checks, and boolean flags instead of verbose API payloads.
 - **Deployment environment management** — Configure wait timers, reviewers, and branch policies for deployment environments alongside your other settings.
 - **Advanced security and CodeQL** — Toggle secret scanning, push protection, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup. License- and ownership-aware: GHAS-licensed fields warn instead of failing on private repos without a license, and org-only fields are silently skipped on personal accounts.
-- **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, and environments. Change the group config, sync once, and every repo updates.
+- **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, environments, security toggles, and code scanning configuration. Change the group config, sync once, and every repo updates.
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.
 
@@ -100,6 +100,7 @@ Full reference guides are in the [docs/](docs/) folder:
 - [Secrets and Variables](docs/secrets-and-variables.md) - resource groups, three kinds (file/value/resolved), and scoping
 - [Rulesets](docs/rulesets.md) - branch and tag ruleset configuration
 - [Environments](docs/environments.md) - deployment environment setup
+- [Advanced Security](docs/configuration.md#security-and-analysis-nested-block) - secret scanning, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup
 - [Cleanup](docs/cleanup.md) - automatic cleanup of undeclared resources
 - [Token Permissions](docs/token-permissions.md) - GitHub PAT setup guide
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 
-Declarative GitHub repository management. Define your repo settings, secrets, variables, rulesets, and deployment environments in a TOML config file, then apply them across all your repositories with a single command.
+Declarative GitHub repository management. Define your repo settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup in a TOML config file, then apply them across all your repositories with a single command.
 
 ## Why reposets
 
@@ -17,6 +17,7 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Multi-scope secret and variable management** — Assign the same secret group to Actions, Dependabot, Codespaces, and deployment environments with scoped targeting.
 - **Ruleset shorthand syntax** — Define branch and tag rulesets with compact inline syntax for pull request rules, status checks, and boolean flags instead of verbose API payloads.
 - **Deployment environment management** — Configure wait timers, reviewers, and branch policies for deployment environments alongside your other settings.
+- **Advanced security and CodeQL** — Toggle secret scanning, push protection, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup. License- and ownership-aware: GHAS-licensed fields warn instead of failing on private repos without a license, and org-only fields are silently skipped on personal accounts.
 - **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, and environments. Change the group config, sync once, and every repo updates.
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| --- | --- |
+| Latest | Yes |
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please email [security@beggs.codes](mailto:security@spencerbeg.gs).
+
+Please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes (optional)
+
+We will acknowledge receipt within 72 hours and provide updates as we investigate. We appreciate responsible disclosure and will credit reporters in release notes unless anonymity is requested.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # reposets Documentation
 
-reposets is a CLI tool for syncing GitHub repository settings, secrets, variables, rulesets, and deployment environments across your personal repositories. Define your desired state once in a TOML config file and apply it everywhere with a single command.
+reposets is a CLI tool for syncing GitHub repository settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup across your personal and organization repositories. Define your desired state once in a TOML config file and apply it everywhere with a single command.
 
 Rather than clicking through repository settings one by one, reposets lets you manage repository configuration as code. Group repositories together, assign shared secrets and variables to those groups, and let reposets reconcile the live state on GitHub against your declared config on every run.
 
@@ -70,5 +70,6 @@ reposets sync
 - [Secrets and Variables](secrets-and-variables.md) - resource groups, three kinds (file/value/resolved), and scoping
 - [Rulesets](rulesets.md) - branch and tag rulesets, shorthand fields, and rule types
 - [Environments](environments.md) - deployment environment definitions and configuration
+- [Advanced Security](configuration.md#security-and-analysis-nested-block) - secret scanning, push protection, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup
 - [Cleanup](cleanup.md) - automatic cleanup of undeclared resources with preserve lists
 - [Token Permissions](token-permissions.md) - fine-grained PAT setup guide

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,7 +74,7 @@ group 'my-projects': unknown environment 'nonexistent'
 
 ## doctor
 
-Deep config diagnostics. Runs everything `validate` does, plus Levenshtein-based typo detection for unknown keys at the top level, inside `[groups.*]` sections, and inside `[cleanup]`. This includes typo detection within `[groups.*.cleanup]` sections and their `secrets` and `variables` sub-keys. Reports suggestions such as `unknown key 'has_wikis' -- did you mean 'has_wiki'?`. Also displays the required fine-grained token permissions.
+Deep config diagnostics. Runs everything `validate` does, plus Levenshtein-based typo detection for unknown keys at the top level (now including `security` and `code_scanning`), inside `[groups.*]` sections (also including `security` and `code_scanning`), and inside `[cleanup]`. This includes typo detection within `[groups.*.cleanup]` sections and their `secrets` and `variables` sub-keys. Reports suggestions such as `unknown key 'has_wikis' -- did you mean 'has_wiki'?`. Also displays the required fine-grained token permissions; the printed list now includes Code scanning alerts, Dependabot alerts, Secret scanning alerts, and Organization > Members for advanced security and team-slug resolution.
 
 | Flag | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -42,7 +42,7 @@ reposets sync --config ./my-config/
 
 ## list
 
-Show a config summary. Displays repo groups with their referenced settings, environments, secrets (by scope), variables, rulesets, and credential profile name.
+Show a config summary. Displays repo groups with their referenced settings, environments, secrets (by scope), variables, rulesets, security groups, code scanning groups, and credential profile name.
 
 | Flag | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
@@ -54,7 +54,7 @@ reposets list
 
 ## validate
 
-Validate `reposets.config.toml` against its schema without making any API calls. Checks schema compliance and reference integrity: verifies that referenced settings, secret, variable, and ruleset groups exist; that file paths in `file`-kind secret and variable groups exist on disk; that credential profiles referenced by groups exist in `reposets.credentials.toml`; that groups referencing environments point to environments that are actually defined; and that environment-scoped secret and variable group references are valid.
+Validate `reposets.config.toml` against its schema without making any API calls. Checks schema compliance and reference integrity: verifies that referenced settings, secret, variable, ruleset, security, and code scanning groups exist; that file paths in `file`-kind secret and variable groups exist on disk; that credential profiles referenced by groups exist in `reposets.credentials.toml`; that groups referencing environments point to environments that are actually defined; and that environment-scoped secret and variable group references are valid. Also enforces cross-field constraints inside `[security.*]` and `[code_scanning.*]` groups -- see [Configuration](./configuration.md#validation) for details.
 
 | Flag | Type | Default | Description |
 | :--- | :--- | :------ | :---------- |
@@ -64,7 +64,7 @@ Validate `reposets.config.toml` against its schema without making any API calls.
 reposets validate
 ```
 
-Cross-reference validation (settings, secrets, variables, rulesets, environments) runs automatically during config loading via the `validateConfigRefs` callback. If references are invalid, the error is reported as a config validation failure:
+Cross-reference validation (settings, secrets, variables, rulesets, environments, security, code scanning) runs automatically during config loading via the `validateConfigRefs` callback. If references are invalid, the error is reported as a config validation failure:
 
 ```text
 $ reposets validate

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,6 +42,8 @@ File paths in `file`-kind secret and variable groups resolve relative to the dir
 
 **Security:** `web_commit_signoff_required`
 
+**Advanced security (nested):** `security_and_analysis` (see [Security and Analysis](#security-and-analysis-nested-block) below)
+
 Unknown fields are forwarded to the GitHub API as pass-through, so new GitHub settings can be used before the schema is updated.
 
 ```toml
@@ -60,6 +62,98 @@ Settings groups accept any additional fields beyond the typed ones listed above.
 
 Be careful with pass-through fields -- typos are silently forwarded to the API. Use `reposets doctor` to detect unknown keys.
 
+### Security and Analysis (nested block)
+
+Settings groups accept a nested `security_and_analysis` block that is folded into the same `PATCH /repos/{owner}/{repo}` call as the rest of the settings. Each scalar field accepts `"enabled"` or `"disabled"`.
+
+| Field | Notes |
+| :---- | :---- |
+| `secret_scanning` | Detect committed credentials and sensitive data. |
+| `secret_scanning_push_protection` | Block git pushes containing detected secrets. |
+| `secret_scanning_ai_detection` | (GHAS-licensed) AI-powered detection of generic secrets. |
+| `secret_scanning_non_provider_patterns` | (GHAS-licensed) Detect custom non-provider patterns. |
+| `secret_scanning_delegated_alert_dismissal` | (org-only) Allow delegated dismissal of alerts. |
+| `secret_scanning_delegated_bypass` | (org-only) Allow delegated approval of push-protection bypass. |
+| `dependabot_security_updates` | Open PRs to patch known dependency vulnerabilities. |
+| `delegated_bypass_reviewers` | (org-only) Array of `{ team, mode }` or `{ role, mode }` entries (see below). |
+
+Annotations:
+
+- **(GHAS-licensed)** -- requires a GitHub Advanced Security license on private repos. Free on public repos. If applied to a private repo without a license, reposets logs a warning and continues; the run does not fail.
+- **(org-only)** -- silently skipped on personal accounts with a logged warning. Owner type is detected once per group via the GitHub API.
+
+```toml
+[settings.oss-defaults.security_and_analysis]
+secret_scanning = "enabled"
+secret_scanning_push_protection = "enabled"
+secret_scanning_ai_detection = "enabled"
+dependabot_security_updates = "enabled"
+```
+
+#### Delegated bypass reviewers
+
+`delegated_bypass_reviewers` is an array of objects, each specifying exactly one of `team` (a GitHub team slug) or `role` (a repository role name like `"admin"` or `"maintain"`), plus an optional `mode` (`"ALWAYS"` or `"EXEMPT"`):
+
+```toml
+[[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
+team = "security-team"
+mode = "ALWAYS"
+
+[[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
+role = "admin"
+mode = "EXEMPT"
+```
+
+Team slugs are resolved to numeric reviewer IDs at sync time using the GitHub API (cached per `org:slug`). Resolving teams requires the `Organization > Members (Read)` token permission.
+
+## Security Groups
+
+`[security.<name>]` tables toggle repository-level security features that have dedicated `PUT`/`DELETE` endpoints, separate from the main repo settings call. reposets diffs each field against the current state and only applies changes.
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `vulnerability_alerts` | boolean | Enable Dependabot vulnerability alerts. |
+| `automated_security_fixes` | boolean | Enable Dependabot security pull requests. Requires `vulnerability_alerts = true`. |
+| `private_vulnerability_reporting` | boolean | Enable the private vulnerability reporting inbox. |
+
+Omitted keys are left untouched on the repo.
+
+```toml
+[security.oss-defaults]
+vulnerability_alerts = true
+automated_security_fixes = true
+private_vulnerability_reporting = true
+```
+
+Reference security groups from a repo group via the `security` array (see [Groups](#groups)).
+
+## Code Scanning Groups
+
+`[code_scanning.<name>]` tables configure CodeQL default setup. The settings are applied via `PATCH /repos/{owner}/{repo}/code-scanning/default-setup`. The endpoint returns `202 Accepted` and is fire-and-forget by default; in `--log-level verbose` mode reposets polls until the configuration is applied.
+
+| Field | Type | Description |
+| :---- | :--- | :---------- |
+| `state` | `"configured"` \| `"not-configured"` | Enable or disable default setup. |
+| `languages` | array | Subset of CodeQL default-setup languages to analyze (see below). |
+| `query_suite` | `"default"` \| `"extended"` | Standard query set or extended security queries. |
+| `threat_model` | `"remote"` \| `"remote_and_local"` | Network sources only, or include filesystem and environment access. |
+| `runner_type` | `"standard"` \| `"labeled"` | GitHub-hosted runners or self-hosted runners by label. |
+| `runner_label` | string | Self-hosted runner label. Required when `runner_type = "labeled"`. |
+
+The `languages` array accepts a subset of GitHub's nine default-setup languages: `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby`, `swift`. (Note: this is narrower than the CodeQL analyzer itself -- Rust is supported by CodeQL but not yet by default setup.)
+
+At sync time, reposets filters configured languages against the languages GitHub detects in the repository. Languages not detected are dropped with a warning; the rest are applied without failing the run.
+
+```toml
+[code_scanning.oss-defaults]
+state = "configured"
+languages = ["javascript-typescript", "python"]
+query_suite = "extended"
+threat_model = "remote"
+```
+
+Reference code scanning groups from a repo group via the `code_scanning` array (see [Groups](#groups)).
+
 ## Groups
 
 `[groups.<name>]` tables tie repositories to resources. Each group maps a list of repos to the settings, environments, secrets, variables, and rulesets that should be applied to them.
@@ -74,6 +168,8 @@ Be careful with pass-through fields -- typos are silently forwarded to the API. 
 | `secrets` | SecretScopes | no | Secret assignments by scope (see [Secrets and Variables](secrets-and-variables.md)) |
 | `variables` | VariableScopes | no | Variable assignments by scope (see [Secrets and Variables](secrets-and-variables.md)) |
 | `rulesets` | string[] | no | Ruleset names to apply |
+| `security` | string[] | no | Security group names to apply (see [Security Groups](#security-groups)) |
+| `code_scanning` | string[] | no | Code scanning group names to apply (see [Code Scanning Groups](#code-scanning-groups)) |
 | `cleanup` | object | no | Per-group cleanup config (see [Cleanup](cleanup.md)) |
 
 ```toml
@@ -84,6 +180,8 @@ environments = ["staging", "production"]
 secrets = { actions = ["deploy", "api"], dependabot = ["deploy"], environments = { production = ["api"] } }
 variables = { actions = ["turbo", "bot"], environments = { staging = ["turbo"] } }
 rulesets = ["branch-protection"]
+security = ["oss-defaults"]
+code_scanning = ["oss-defaults"]
 ```
 
 ## Editor Support
@@ -107,6 +205,21 @@ log_level = "info"
 has_wiki = false
 has_discussions = false
 delete_branch_on_merge = true
+
+[settings.default.security_and_analysis]
+secret_scanning = "enabled"
+secret_scanning_push_protection = "enabled"
+dependabot_security_updates = "enabled"
+
+[security.oss-defaults]
+vulnerability_alerts = true
+automated_security_fixes = true
+private_vulnerability_reporting = true
+
+[code_scanning.oss-defaults]
+state = "configured"
+languages = ["javascript-typescript"]
+query_suite = "default"
 
 [environments.staging]
 wait_timer = 0
@@ -156,6 +269,8 @@ environments = ["staging", "production"]
 secrets = { actions = ["deploy", "api"], dependabot = ["deploy"], environments = { production = ["api"] } }
 variables = { actions = ["turbo", "bot"], environments = { staging = ["turbo"] } }
 rulesets = ["branch-protection"]
+security = ["oss-defaults"]
+code_scanning = ["oss-defaults"]
 cleanup = {
   rulesets = true,
   environments = true,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ dependabot_security_updates = "enabled"
 
 #### Delegated bypass reviewers
 
-`delegated_bypass_reviewers` is an array of objects, each specifying exactly one of `team` (a GitHub team slug) or `role` (a repository role name like `"admin"` or `"maintain"`), plus an optional `mode` (`"ALWAYS"` or `"EXEMPT"`):
+`delegated_bypass_reviewers` is an array of objects, each specifying exactly one of `team` (a GitHub team slug) or `role` (an organization role name from `GET /orgs/{org}/organization-roles`, e.g. `"all_repo_admin"`, `"all_repo_maintain"`, or a custom role like `"security_manager"`), plus an optional `mode` (`"ALWAYS"` or `"EXEMPT"`):
 
 ```toml
 [[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
@@ -102,11 +102,11 @@ team = "security-team"
 mode = "ALWAYS"
 
 [[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
-role = "admin"
+role = "all_repo_admin"
 mode = "EXEMPT"
 ```
 
-Team slugs are resolved to numeric reviewer IDs at sync time using the GitHub API (cached per `org:slug`). Resolving teams requires the `Organization > Members (Read)` token permission.
+Both team slugs and role names are resolved to numeric reviewer IDs at sync time using the GitHub API and cached per `org:slug` and `org:name`. The exact role names available to your org are visible at `GET /orgs/{org}/organization-roles`; they include the predefined `all_repo_*` family (`all_repo_admin`, `all_repo_maintain`, `all_repo_write`, `all_repo_triage`, `all_repo_read`) plus any custom organization roles defined for the org. Note that role IDs are per-org even for predefined roles, so a config that works against one org cannot reuse hard-coded numeric IDs against another. Resolving teams and roles requires the `Organization > Members (Read)` token permission.
 
 ## Security Groups
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,8 @@ Settings groups accept a nested `security_and_analysis` block that is folded int
 
 | Field | Notes |
 | :---- | :---- |
+| `advanced_security` | (GHAS-licensed) Master toggle for GitHub Advanced Security features on the repository. |
+| `code_security` | (GHAS-licensed) Toggle GitHub Code Security functionality. |
 | `secret_scanning` | Detect committed credentials and sensitive data. |
 | `secret_scanning_push_protection` | Block git pushes containing detected secrets. |
 | `secret_scanning_ai_detection` | (GHAS-licensed) AI-powered detection of generic secrets. |
@@ -127,6 +129,19 @@ private_vulnerability_reporting = true
 
 Reference security groups from a repo group via the `security` array (see [Groups](#groups)).
 
+### Validation
+
+The schema rejects `automated_security_fixes = true` paired with `vulnerability_alerts = false` in the same group at config-load time (so `reposets validate` fails before any sync runs):
+
+```text
+automated_security_fixes = true requires vulnerability_alerts to be enabled
+(or omitted to leave the existing setting in place)
+```
+
+Omitting `vulnerability_alerts` entirely is permitted -- the existing repo state may already satisfy the requirement, and the "leave alone" semantic is preserved.
+
+When a repo references multiple `[security.*]` groups, reposets merges them with last-write-wins semantics. If the merge produces the same contradiction (for example, one group sets `vulnerability_alerts = false` and another sets `automated_security_fixes = true`), reposets detects this at sync time, logs an error, and skips the security stage for the affected repos rather than failing at the GitHub API. Restructure your security groups so the contradiction cannot arise on merge.
+
 ## Code Scanning Groups
 
 `[code_scanning.<name>]` tables configure CodeQL default setup. The settings are applied via `PATCH /repos/{owner}/{repo}/code-scanning/default-setup`. The endpoint returns `202 Accepted` and configures asynchronously; reposets sends the request and does not poll for completion.
@@ -150,6 +165,12 @@ state = "configured"
 languages = ["javascript-typescript", "python"]
 query_suite = "extended"
 threat_model = "remote"
+```
+
+The schema rejects `runner_type = "labeled"` without a corresponding `runner_label` at config-load time:
+
+```text
+runner_label is required when runner_type = "labeled"
 ```
 
 Reference code scanning groups from a repo group via the `code_scanning` array (see [Groups](#groups)).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,7 +129,7 @@ Reference security groups from a repo group via the `security` array (see [Group
 
 ## Code Scanning Groups
 
-`[code_scanning.<name>]` tables configure CodeQL default setup. The settings are applied via `PATCH /repos/{owner}/{repo}/code-scanning/default-setup`. The endpoint returns `202 Accepted` and is fire-and-forget by default; in `--log-level verbose` mode reposets polls until the configuration is applied.
+`[code_scanning.<name>]` tables configure CodeQL default setup. The settings are applied via `PATCH /repos/{owner}/{repo}/code-scanning/default-setup`. The endpoint returns `202 Accepted` and configures asynchronously; reposets sends the request and does not poll for completion.
 
 | Field | Type | Description |
 | :---- | :--- | :---------- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ File paths in `file`-kind secret and variable groups resolve relative to the dir
 
 **Cleanup:** `delete_branch_on_merge`
 
-**Security:** `web_commit_signoff_required`
+**Commit signing:** `web_commit_signoff_required`
 
 **Advanced security (nested):** `security_and_analysis` (see [Security and Analysis](#security-and-analysis-nested-block) below)
 
@@ -215,6 +215,8 @@ The schemas also include annotations for two TOML-specific language servers:
 - [Taplo](https://taplo.tamasfe.dev/) -- `x-taplo` annotations for documentation links and key scaffolding via `initKeys`
 
 If you use Tombi or Taplo as your TOML language server, you get richer editor integration including contextual documentation links that point to the relevant section of this documentation.
+
+Field-level descriptions in the schema include the same `(GHAS-licensed)` and `(org-only)` annotations used in this documentation, so editors that surface schema descriptions on hover (VS Code, IntelliJ, Neovim with a TOML LSP) show the licensing and ownership requirements for each field as you write the config.
 
 ## Complete Example
 

--- a/docs/token-permissions.md
+++ b/docs/token-permissions.md
@@ -12,7 +12,13 @@ reposets requires a fine-grained personal access token (not a classic token). Fi
 | Repository | Secrets | Read and write | Manage Actions, Dependabot, and Codespaces secrets |
 | Repository | Variables | Read and write | Manage Actions and environment variables |
 | Repository | Environments | Read and write | Create and configure deployment environments |
+| Repository | Code scanning alerts | Read and write | Configure CodeQL default setup (`[code_scanning.*]`) |
+| Repository | Dependabot alerts | Read and write | Toggle vulnerability alerts and automated security fixes (`[security.*]`) |
+| Repository | Secret scanning alerts | Read and write | Configure `security_and_analysis` secret scanning fields |
+| Organization | Members | Read | Resolve team slugs in `delegated_bypass_reviewers` to numeric reviewer IDs (org-owned repos only) |
 | Account | GPG keys | Read and write | Retrieve the repository public key for encrypting secrets (see below) |
+
+The four security-related permissions (Code scanning alerts, Dependabot alerts, Secret scanning alerts, Members) are only required if you use the corresponding config sections (`[settings.*.security_and_analysis]`, `[security.*]`, `[code_scanning.*]`). Tokens without them can still sync settings, secrets, variables, rulesets, and environments.
 
 ### Why GPG Keys Access Is Required
 
@@ -24,9 +30,10 @@ The GitHub API does not accept secret values in plaintext. Before uploading a se
 2. Click "Generate new token"
 3. Set a token name and expiration
 4. Under "Repository access", select "All repositories" or choose specific repos
-5. Under "Repository permissions", enable the four required permissions listed above
+5. Under "Repository permissions", enable the required permissions listed above (Administration, Secrets, Variables, Environments, plus Code scanning alerts / Dependabot alerts / Secret scanning alerts if you use the security config sections)
 6. Under "Account permissions", enable GPG keys (Read and write)
-7. Click "Generate token" and copy it
+7. Under "Organization permissions", enable Members (Read) if you use `delegated_bypass_reviewers` with team slugs on org-owned repos
+8. Click "Generate token" and copy it
 
 ## Adding the Token
 

--- a/package/README.md
+++ b/package/README.md
@@ -18,7 +18,7 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Ruleset shorthand syntax** — Define branch and tag rulesets with compact inline syntax for pull request rules, status checks, and boolean flags instead of verbose API payloads.
 - **Deployment environment management** — Configure wait timers, reviewers, and branch policies for deployment environments alongside your other settings.
 - **Advanced security and CodeQL** — Toggle secret scanning, push protection, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup. License- and ownership-aware: GHAS-licensed fields warn instead of failing on private repos without a license, and org-only fields are silently skipped on personal accounts.
-- **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, and environments. Change the group config, sync once, and every repo updates.
+- **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, environments, security toggles, and code scanning configuration. Change the group config, sync once, and every repo updates.
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.
 
@@ -131,6 +131,7 @@ Full reference guides are available in the [`docs/`](https://github.com/spencerb
 - [Secrets and Variables](https://github.com/spencerbeggs/reposets/blob/main/docs/secrets-and-variables.md) - resource groups, three kinds (file/value/resolved), and scoping
 - [Rulesets](https://github.com/spencerbeggs/reposets/blob/main/docs/rulesets.md) - branch and tag ruleset configuration
 - [Environments](https://github.com/spencerbeggs/reposets/blob/main/docs/environments.md) - deployment environment setup
+- [Advanced Security](https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md#security-and-analysis-nested-block) - secret scanning, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup
 - [Cleanup](https://github.com/spencerbeggs/reposets/blob/main/docs/cleanup.md) - automatic cleanup of undeclared resources
 - [Token Permissions](https://github.com/spencerbeggs/reposets/blob/main/docs/token-permissions.md) - GitHub PAT setup guide
 

--- a/package/README.md
+++ b/package/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 
-Declarative GitHub repository management. Define your repo settings, secrets, variables, rulesets, and deployment environments in a TOML config file, then apply them across all your repositories with a single command.
+Declarative GitHub repository management. Define your repo settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup in a TOML config file, then apply them across all your repositories with a single command.
 
 ## Why reposets
 
@@ -17,6 +17,7 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Multi-scope secret and variable management** — Assign the same secret group to Actions, Dependabot, Codespaces, and deployment environments with scoped targeting.
 - **Ruleset shorthand syntax** — Define branch and tag rulesets with compact inline syntax for pull request rules, status checks, and boolean flags instead of verbose API payloads.
 - **Deployment environment management** — Configure wait timers, reviewers, and branch policies for deployment environments alongside your other settings.
+- **Advanced security and CodeQL** — Toggle secret scanning, push protection, vulnerability alerts, automated security fixes, private vulnerability reporting, and CodeQL default setup. License- and ownership-aware: GHAS-licensed fields warn instead of failing on private repos without a license, and org-only fields are silently skipped on personal accounts.
 - **Group-based targeting** — Organize repos into groups that share settings, secrets, variables, rulesets, and environments. Change the group config, sync once, and every repo updates.
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.
@@ -93,7 +94,7 @@ All commands accept `--log-level silent|info|verbose|debug`.
 
 reposets uses two TOML files:
 
-- `reposets.config.toml` — defines settings, secrets, variables, rulesets, environments, and groups
+- `reposets.config.toml` — defines settings, secrets, variables, rulesets, environments, security, code_scanning, and groups
 - `reposets.credentials.toml` — stores GitHub tokens and optional resolve sections for named values
 
 Config lookup order (first match wins):
@@ -112,7 +113,13 @@ reposets requires a fine-grained personal access token with:
 - Repository > Secrets (Read and write)
 - Repository > Variables (Read and write)
 - Repository > Environments (Read and write)
+- Repository > Code scanning alerts (Read and write) — for `[code_scanning.*]`
+- Repository > Dependabot alerts (Read and write) — for `[security.*]`
+- Repository > Secret scanning alerts (Read and write) — for `security_and_analysis`
+- Organization > Members (Read) — for `delegated_bypass_reviewers` team slugs on org-owned repos
 - Account > GPG keys (Read and write)
+
+The four security-related scopes are only required if you use the corresponding config sections.
 
 ## Documentation
 

--- a/package/__test__/fixtures/bad-code-scanning-refs.toml
+++ b/package/__test__/fixtures/bad-code-scanning-refs.toml
@@ -1,0 +1,3 @@
+[groups.my-projects]
+repos = ["repo-one"]
+code_scanning = ["nonexistent-code-scanning"]

--- a/package/__test__/fixtures/bad-refs.toml
+++ b/package/__test__/fixtures/bad-refs.toml
@@ -7,5 +7,3 @@ settings = ["nonexistent-settings"]
 secrets = { actions = ["nonexistent-secrets"] }
 variables = { actions = ["nonexistent-vars"] }
 rulesets = ["nonexistent-ruleset"]
-security = ["nonexistent-security"]
-code_scanning = ["nonexistent-code-scanning"]

--- a/package/__test__/fixtures/bad-refs.toml
+++ b/package/__test__/fixtures/bad-refs.toml
@@ -7,3 +7,5 @@ settings = ["nonexistent-settings"]
 secrets = { actions = ["nonexistent-secrets"] }
 variables = { actions = ["nonexistent-vars"] }
 rulesets = ["nonexistent-ruleset"]
+security = ["nonexistent-security"]
+code_scanning = ["nonexistent-code-scanning"]

--- a/package/__test__/fixtures/bad-security-refs.toml
+++ b/package/__test__/fixtures/bad-security-refs.toml
@@ -1,0 +1,3 @@
+[groups.my-projects]
+repos = ["repo-one"]
+security = ["nonexistent-security"]

--- a/package/__test__/schemas/config.test.ts
+++ b/package/__test__/schemas/config.test.ts
@@ -237,17 +237,6 @@ describe("VariableScopesSchema", () => {
 });
 
 describe("SecurityAndAnalysis (nested in SettingsGroupSchema)", () => {
-	const decodeSettings = Schema.decodeUnknownSync(
-		Schema.Struct({}).pipe(
-			Schema.extend(
-				Schema.Struct({
-					security_and_analysis: Schema.Any,
-				}),
-			),
-		),
-	);
-	void decodeSettings;
-
 	it("accepts security_and_analysis nested in a settings group", () => {
 		const result = decodeConfig({
 			settings: {

--- a/package/__test__/schemas/config.test.ts
+++ b/package/__test__/schemas/config.test.ts
@@ -315,6 +315,21 @@ describe("SecurityGroupSchema", () => {
 		const result = decodeSecurityGroup({});
 		expect(result.vulnerability_alerts).toBeUndefined();
 	});
+
+	it("accepts automated_security_fixes = true with vulnerability_alerts omitted (leave-alone semantic)", () => {
+		const result = decodeSecurityGroup({ automated_security_fixes: true });
+		expect(result.automated_security_fixes).toBe(true);
+		expect(result.vulnerability_alerts).toBeUndefined();
+	});
+
+	it("rejects automated_security_fixes = true with vulnerability_alerts = false (explicit contradiction)", () => {
+		expect(() =>
+			decodeSecurityGroup({
+				automated_security_fixes: true,
+				vulnerability_alerts: false,
+			}),
+		).toThrow(/automated_security_fixes/);
+	});
 });
 
 describe("CodeScanningLanguageSchema", () => {
@@ -373,6 +388,16 @@ describe("CodeScanningGroupSchema", () => {
 
 	it("rejects unsupported query suite", () => {
 		expect(() => decodeCodeScanningGroup({ query_suite: "minimal" })).toThrow();
+	});
+
+	it('rejects runner_type = "labeled" without runner_label', () => {
+		expect(() => decodeCodeScanningGroup({ runner_type: "labeled" })).toThrow(/runner_label is required/);
+	});
+
+	it('accepts runner_type = "standard" without runner_label', () => {
+		const result = decodeCodeScanningGroup({ runner_type: "standard" });
+		expect(result.runner_type).toBe("standard");
+		expect(result.runner_label).toBeUndefined();
 	});
 });
 

--- a/package/__test__/schemas/config.test.ts
+++ b/package/__test__/schemas/config.test.ts
@@ -1,11 +1,22 @@
 import { Schema } from "effect";
 import { describe, expect, it } from "vitest";
-import { ConfigSchema, GroupSchema, SecretScopesSchema, VariableScopesSchema } from "../../src/schemas/config.js";
+import {
+	CodeScanningGroupSchema,
+	CodeScanningLanguageSchema,
+	ConfigSchema,
+	GroupSchema,
+	SecretScopesSchema,
+	SecurityGroupSchema,
+	VariableScopesSchema,
+} from "../../src/schemas/config.js";
 
 const decodeConfig = Schema.decodeUnknownSync(ConfigSchema);
 const decodeGroup = Schema.decodeUnknownSync(GroupSchema);
 const decodeSecretScopes = Schema.decodeUnknownSync(SecretScopesSchema);
 const decodeVariableScopes = Schema.decodeUnknownSync(VariableScopesSchema);
+const decodeSecurityGroup = Schema.decodeUnknownSync(SecurityGroupSchema);
+const decodeCodeScanningGroup = Schema.decodeUnknownSync(CodeScanningGroupSchema);
+const decodeCodeScanningLanguage = Schema.decodeUnknownSync(CodeScanningLanguageSchema);
 
 describe("GroupSchema", () => {
 	it("accepts minimal group", () => {
@@ -222,5 +233,194 @@ describe("VariableScopesSchema", () => {
 		const result = decodeVariableScopes({ actions: ["common"] });
 		expect(result.actions).toEqual(["common"]);
 		expect(result.environments).toBeUndefined();
+	});
+});
+
+describe("SecurityAndAnalysis (nested in SettingsGroupSchema)", () => {
+	const decodeSettings = Schema.decodeUnknownSync(
+		Schema.Struct({}).pipe(
+			Schema.extend(
+				Schema.Struct({
+					security_and_analysis: Schema.Any,
+				}),
+			),
+		),
+	);
+	void decodeSettings;
+
+	it("accepts security_and_analysis nested in a settings group", () => {
+		const result = decodeConfig({
+			settings: {
+				oss: {
+					security_and_analysis: {
+						secret_scanning: "enabled",
+						secret_scanning_push_protection: "enabled",
+						dependabot_security_updates: "enabled",
+					},
+				},
+			},
+			groups: { g: { repos: ["r"] } },
+		});
+		const saa = result.settings.oss?.security_and_analysis;
+		expect(saa?.secret_scanning).toBe("enabled");
+		expect(saa?.secret_scanning_push_protection).toBe("enabled");
+		expect(saa?.dependabot_security_updates).toBe("enabled");
+	});
+
+	it("rejects invalid status values", () => {
+		expect(() =>
+			decodeConfig({
+				settings: { oss: { security_and_analysis: { secret_scanning: "on" } } },
+				groups: { g: { repos: ["r"] } },
+			}),
+		).toThrow();
+	});
+
+	it("accepts delegated_bypass_reviewers with team and role variants", () => {
+		const result = decodeConfig({
+			settings: {
+				oss: {
+					security_and_analysis: {
+						secret_scanning_delegated_bypass: "enabled",
+						delegated_bypass_reviewers: [{ team: "security-team", mode: "ALWAYS" }, { role: "admin" }],
+					},
+				},
+			},
+			groups: { g: { repos: ["r"] } },
+		});
+		const reviewers = result.settings.oss?.security_and_analysis?.delegated_bypass_reviewers;
+		expect(reviewers).toHaveLength(2);
+		expect(reviewers?.[0]).toMatchObject({ team: "security-team", mode: "ALWAYS" });
+		expect(reviewers?.[1]).toMatchObject({ role: "admin" });
+	});
+
+	it("rejects invalid reviewer mode", () => {
+		expect(() =>
+			decodeConfig({
+				settings: {
+					oss: {
+						security_and_analysis: {
+							delegated_bypass_reviewers: [{ team: "x", mode: "MAYBE" }],
+						},
+					},
+				},
+				groups: { g: { repos: ["r"] } },
+			}),
+		).toThrow();
+	});
+});
+
+describe("SecurityGroupSchema", () => {
+	it("accepts all toggles", () => {
+		const result = decodeSecurityGroup({
+			vulnerability_alerts: true,
+			automated_security_fixes: true,
+			private_vulnerability_reporting: false,
+		});
+		expect(result.vulnerability_alerts).toBe(true);
+		expect(result.automated_security_fixes).toBe(true);
+		expect(result.private_vulnerability_reporting).toBe(false);
+	});
+
+	it("accepts an empty group (all fields optional)", () => {
+		const result = decodeSecurityGroup({});
+		expect(result.vulnerability_alerts).toBeUndefined();
+	});
+});
+
+describe("CodeScanningLanguageSchema", () => {
+	it("accepts every documented default-setup language", () => {
+		for (const lang of [
+			"actions",
+			"c-cpp",
+			"csharp",
+			"go",
+			"java-kotlin",
+			"javascript-typescript",
+			"python",
+			"ruby",
+			"swift",
+		]) {
+			expect(decodeCodeScanningLanguage(lang)).toBe(lang);
+		}
+	});
+
+	it("rejects rust (CodeQL supports it but default setup does not)", () => {
+		expect(() => decodeCodeScanningLanguage("rust")).toThrow();
+	});
+
+	it("rejects arbitrary strings", () => {
+		expect(() => decodeCodeScanningLanguage("kotlin")).toThrow();
+	});
+});
+
+describe("CodeScanningGroupSchema", () => {
+	it("accepts a fully-populated group", () => {
+		const result = decodeCodeScanningGroup({
+			state: "configured",
+			languages: ["javascript-typescript", "python"],
+			query_suite: "extended",
+			threat_model: "remote",
+			runner_type: "standard",
+		});
+		expect(result.state).toBe("configured");
+		expect(result.languages).toEqual(["javascript-typescript", "python"]);
+		expect(result.query_suite).toBe("extended");
+	});
+
+	it("accepts state = not-configured to disable scanning", () => {
+		const result = decodeCodeScanningGroup({ state: "not-configured" });
+		expect(result.state).toBe("not-configured");
+	});
+
+	it("accepts labeled runner with runner_label", () => {
+		const result = decodeCodeScanningGroup({
+			runner_type: "labeled",
+			runner_label: "ubuntu-large",
+		});
+		expect(result.runner_type).toBe("labeled");
+		expect(result.runner_label).toBe("ubuntu-large");
+	});
+
+	it("rejects unsupported query suite", () => {
+		expect(() => decodeCodeScanningGroup({ query_suite: "minimal" })).toThrow();
+	});
+});
+
+describe("ConfigSchema with security and code_scanning", () => {
+	it("accepts top-level security and code_scanning groups", () => {
+		const result = decodeConfig({
+			security: {
+				oss: { vulnerability_alerts: true, automated_security_fixes: true },
+			},
+			code_scanning: {
+				oss: { state: "configured", languages: ["javascript-typescript"] },
+			},
+			groups: {
+				g: { repos: ["r"], security: ["oss"], code_scanning: ["oss"] },
+			},
+		});
+		expect(result.security?.oss?.vulnerability_alerts).toBe(true);
+		expect(result.code_scanning?.oss?.state).toBe("configured");
+		expect(result.groups.g?.security).toEqual(["oss"]);
+		expect(result.groups.g?.code_scanning).toEqual(["oss"]);
+	});
+
+	it("applies empty defaults for security and code_scanning when omitted", () => {
+		const result = decodeConfig({ groups: { g: { repos: ["r"] } } });
+		expect(result.security).toEqual({});
+		expect(result.code_scanning).toEqual({});
+	});
+});
+
+describe("GroupSchema with security/code_scanning refs", () => {
+	it("accepts security and code_scanning string arrays on a group", () => {
+		const result = decodeGroup({
+			repos: ["r"],
+			security: ["oss-defaults"],
+			code_scanning: ["oss-defaults"],
+		});
+		expect(result.security).toEqual(["oss-defaults"]);
+		expect(result.code_scanning).toEqual(["oss-defaults"]);
 	});
 });

--- a/package/__test__/services/ConfigFiles.int.test.ts
+++ b/package/__test__/services/ConfigFiles.int.test.ts
@@ -232,7 +232,7 @@ describe("validateConfigRefs", () => {
 	});
 
 	it("rejects config with unknown security group reference", async () => {
-		const layer = makeConfigLayer(fixture("bad-refs.toml"));
+		const layer = makeConfigLayer(fixture("bad-security-refs.toml"));
 		const result = await runWithProvider(
 			Effect.gen(function* () {
 				const cf = yield* TestConfigFile;
@@ -249,7 +249,7 @@ describe("validateConfigRefs", () => {
 	});
 
 	it("rejects config with unknown code_scanning group reference", async () => {
-		const layer = makeConfigLayer(fixture("bad-refs.toml"));
+		const layer = makeConfigLayer(fixture("bad-code-scanning-refs.toml"));
 		const result = await runWithProvider(
 			Effect.gen(function* () {
 				const cf = yield* TestConfigFile;

--- a/package/__test__/services/ConfigFiles.int.test.ts
+++ b/package/__test__/services/ConfigFiles.int.test.ts
@@ -231,6 +231,40 @@ describe("validateConfigRefs", () => {
 		}
 	});
 
+	it("rejects config with unknown security group reference", async () => {
+		const layer = makeConfigLayer(fixture("bad-refs.toml"));
+		const result = await runWithProvider(
+			Effect.gen(function* () {
+				const cf = yield* TestConfigFile;
+				return yield* Effect.either(cf.load);
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(result._tag).toBe("Left");
+		if (result._tag === "Left") {
+			const error = result.left as ConfigError;
+			expect(error._tag).toBe("ConfigError");
+			expect(error.reason).toContain("unknown security group 'nonexistent-security'");
+		}
+	});
+
+	it("rejects config with unknown code_scanning group reference", async () => {
+		const layer = makeConfigLayer(fixture("bad-refs.toml"));
+		const result = await runWithProvider(
+			Effect.gen(function* () {
+				const cf = yield* TestConfigFile;
+				return yield* Effect.either(cf.load);
+			}).pipe(Effect.provide(layer)),
+		);
+
+		expect(result._tag).toBe("Left");
+		if (result._tag === "Left") {
+			const error = result.left as ConfigError;
+			expect(error._tag).toBe("ConfigError");
+			expect(error.reason).toContain("unknown code_scanning group 'nonexistent-code-scanning'");
+		}
+	});
+
 	it("rejects config with unknown environment reference", async () => {
 		const layer = makeConfigLayer(fixture("bad-env-refs.toml"));
 		const result = await runWithProvider(

--- a/package/__test__/services/GitHubClient.test.ts
+++ b/package/__test__/services/GitHubClient.test.ts
@@ -307,6 +307,17 @@ describe("GitHubClient", () => {
 		it("ignores invalid status values", () => {
 			expect(transformSecurityAndAnalysis({ secret_scanning: "on" })).toBeUndefined();
 		});
+
+		it("treats empty delegated_bypass_reviewers array as no-op (not as a clear-all)", () => {
+			expect(
+				transformSecurityAndAnalysis({
+					secret_scanning_delegated_bypass: "enabled",
+					delegated_bypass_reviewers: [],
+				}),
+			).toEqual({
+				secret_scanning_delegated_bypass: { status: "enabled" },
+			});
+		});
 	});
 
 	describe("Test implementation - security methods", () => {

--- a/package/__test__/services/GitHubClient.test.ts
+++ b/package/__test__/services/GitHubClient.test.ts
@@ -431,5 +431,21 @@ describe("GitHubClient", () => {
 				args: { org: "my-org", slug: "security-team" },
 			});
 		});
+
+		it("records resolveRoleId calls and returns 0", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				return yield* client.resolveRoleId("my-org", "all_repo_admin");
+			}).pipe(Effect.provide(recorder.layer));
+
+			const result = await Effect.runPromise(program);
+			expect(result).toBe(0);
+			expect(recorder.calls()).toContainEqual({
+				method: "resolveRoleId",
+				args: { org: "my-org", name: "all_repo_admin" },
+			});
+		});
 	});
 });

--- a/package/__test__/services/GitHubClient.test.ts
+++ b/package/__test__/services/GitHubClient.test.ts
@@ -5,6 +5,7 @@ import {
 	GitHubClient,
 	GitHubClientTest,
 	ORG_ONLY_SETTINGS,
+	transformSecurityAndAnalysis,
 } from "../../src/services/GitHubClient.js";
 
 describe("GitHubClient", () => {
@@ -257,6 +258,179 @@ describe("GitHubClient", () => {
 	describe("ORG_ONLY_SETTINGS", () => {
 		it("contains allow_forking", () => {
 			expect(ORG_ONLY_SETTINGS.has("allow_forking")).toBe(true);
+		});
+	});
+
+	describe("transformSecurityAndAnalysis", () => {
+		it("wraps status fields in { status } objects", () => {
+			const result = transformSecurityAndAnalysis({
+				secret_scanning: "enabled",
+				secret_scanning_push_protection: "disabled",
+				dependabot_security_updates: "enabled",
+			});
+			expect(result).toEqual({
+				secret_scanning: { status: "enabled" },
+				secret_scanning_push_protection: { status: "disabled" },
+				dependabot_security_updates: { status: "enabled" },
+			});
+		});
+
+		it("renames delegated_bypass_reviewers to secret_scanning_delegated_bypass_options.reviewers", () => {
+			const result = transformSecurityAndAnalysis({
+				secret_scanning_delegated_bypass: "enabled",
+				delegated_bypass_reviewers: [{ reviewer_id: 12345, reviewer_type: "TEAM", mode: "ALWAYS" }],
+			});
+			expect(result).toEqual({
+				secret_scanning_delegated_bypass: { status: "enabled" },
+				secret_scanning_delegated_bypass_options: {
+					reviewers: [{ reviewer_id: 12345, reviewer_type: "TEAM", mode: "ALWAYS" }],
+				},
+			});
+		});
+
+		it("ignores unknown fields", () => {
+			const result = transformSecurityAndAnalysis({ secret_scanning: "enabled", random_field: "x" });
+			expect(result).toEqual({ secret_scanning: { status: "enabled" } });
+		});
+
+		it("returns undefined for non-object input", () => {
+			expect(transformSecurityAndAnalysis(null)).toBeUndefined();
+			expect(transformSecurityAndAnalysis("string")).toBeUndefined();
+			expect(transformSecurityAndAnalysis(undefined)).toBeUndefined();
+		});
+
+		it("returns undefined when no recognised fields are present", () => {
+			expect(transformSecurityAndAnalysis({})).toBeUndefined();
+			expect(transformSecurityAndAnalysis({ random_field: "x" })).toBeUndefined();
+		});
+
+		it("ignores invalid status values", () => {
+			expect(transformSecurityAndAnalysis({ secret_scanning: "on" })).toBeUndefined();
+		});
+	});
+
+	describe("Test implementation - security methods", () => {
+		it("records setVulnerabilityAlerts calls", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				yield* client.setVulnerabilityAlerts("owner", "repo", true);
+				yield* client.setVulnerabilityAlerts("owner", "repo2", false);
+			}).pipe(Effect.provide(recorder.layer));
+
+			await Effect.runPromise(program);
+			expect(recorder.calls()).toContainEqual({
+				method: "setVulnerabilityAlerts",
+				args: { owner: "owner", repo: "repo", enabled: true },
+			});
+			expect(recorder.calls()).toContainEqual({
+				method: "setVulnerabilityAlerts",
+				args: { owner: "owner", repo: "repo2", enabled: false },
+			});
+		});
+
+		it("records setAutomatedSecurityFixes and setPrivateVulnerabilityReporting calls", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				yield* client.setAutomatedSecurityFixes("owner", "repo", true);
+				yield* client.setPrivateVulnerabilityReporting("owner", "repo", true);
+			}).pipe(Effect.provide(recorder.layer));
+
+			await Effect.runPromise(program);
+			const calls = recorder.calls();
+			expect(calls).toContainEqual({
+				method: "setAutomatedSecurityFixes",
+				args: { owner: "owner", repo: "repo", enabled: true },
+			});
+			expect(calls).toContainEqual({
+				method: "setPrivateVulnerabilityReporting",
+				args: { owner: "owner", repo: "repo", enabled: true },
+			});
+		});
+
+		it("getters return false in test implementation", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				const va = yield* client.getVulnerabilityAlerts("o", "r");
+				const asf = yield* client.getAutomatedSecurityFixes("o", "r");
+				const pvr = yield* client.getPrivateVulnerabilityReporting("o", "r");
+				return { va, asf, pvr };
+			}).pipe(Effect.provide(recorder.layer));
+
+			const result = await Effect.runPromise(program);
+			expect(result).toEqual({ va: false, asf: false, pvr: false });
+		});
+
+		it("records updateCodeScanningDefaultSetup calls", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				yield* client.updateCodeScanningDefaultSetup("owner", "repo", {
+					state: "configured",
+					languages: ["javascript-typescript"],
+					query_suite: "extended",
+				});
+			}).pipe(Effect.provide(recorder.layer));
+
+			await Effect.runPromise(program);
+			expect(recorder.calls()).toContainEqual({
+				method: "updateCodeScanningDefaultSetup",
+				args: {
+					owner: "owner",
+					repo: "repo",
+					config: {
+						state: "configured",
+						languages: ["javascript-typescript"],
+						query_suite: "extended",
+					},
+				},
+			});
+		});
+
+		it("getCodeScanningDefaultSetup returns empty object", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				return yield* client.getCodeScanningDefaultSetup("o", "r");
+			}).pipe(Effect.provide(recorder.layer));
+
+			const result = await Effect.runPromise(program);
+			expect(result).toEqual({});
+		});
+
+		it("listRepoLanguages returns empty array", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				return yield* client.listRepoLanguages("o", "r");
+			}).pipe(Effect.provide(recorder.layer));
+
+			const result = await Effect.runPromise(program);
+			expect(result).toEqual([]);
+		});
+
+		it("records resolveTeamId calls and returns 0", async () => {
+			const recorder = GitHubClientTest();
+
+			const program = Effect.gen(function* () {
+				const client = yield* GitHubClient;
+				return yield* client.resolveTeamId("my-org", "security-team");
+			}).pipe(Effect.provide(recorder.layer));
+
+			const result = await Effect.runPromise(program);
+			expect(result).toBe(0);
+			expect(recorder.calls()).toContainEqual({
+				method: "resolveTeamId",
+				args: { org: "my-org", slug: "security-team" },
+			});
 		});
 	});
 });

--- a/package/__test__/services/GitHubClient.test.ts
+++ b/package/__test__/services/GitHubClient.test.ts
@@ -404,18 +404,6 @@ describe("GitHubClient", () => {
 			});
 		});
 
-		it("getCodeScanningDefaultSetup returns empty object", async () => {
-			const recorder = GitHubClientTest();
-
-			const program = Effect.gen(function* () {
-				const client = yield* GitHubClient;
-				return yield* client.getCodeScanningDefaultSetup("o", "r");
-			}).pipe(Effect.provide(recorder.layer));
-
-			const result = await Effect.runPromise(program);
-			expect(result).toEqual({});
-		});
-
 		it("listRepoLanguages returns empty array", async () => {
 			const recorder = GitHubClientTest();
 

--- a/package/__test__/services/SyncEngine.test.ts
+++ b/package/__test__/services/SyncEngine.test.ts
@@ -22,6 +22,8 @@ function makeTestConfig(overrides: Partial<Config> = {}): Config {
 		},
 		rulesets: {},
 		environments: {},
+		security: {},
+		code_scanning: {},
 		groups: {
 			mygroup: {
 				repos: ["repo-one"],
@@ -349,6 +351,16 @@ describe("SyncEngine", () => {
 			deleteEnvironment: () => Effect.void,
 			deleteEnvironmentSecret: () => Effect.void,
 			deleteEnvironmentVariable: () => Effect.void,
+			getVulnerabilityAlerts: () => Effect.succeed(false),
+			setVulnerabilityAlerts: () => Effect.void,
+			getAutomatedSecurityFixes: () => Effect.succeed(false),
+			setAutomatedSecurityFixes: () => Effect.void,
+			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+			setPrivateVulnerabilityReporting: () => Effect.void,
+			getCodeScanningDefaultSetup: () => Effect.succeed({}),
+			updateCodeScanningDefaultSetup: () => Effect.void,
+			listRepoLanguages: () => Effect.succeed([]),
+			resolveTeamId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -426,6 +438,16 @@ describe("SyncEngine", () => {
 			},
 			deleteEnvironmentSecret: () => Effect.void,
 			deleteEnvironmentVariable: () => Effect.void,
+			getVulnerabilityAlerts: () => Effect.succeed(false),
+			setVulnerabilityAlerts: () => Effect.void,
+			getAutomatedSecurityFixes: () => Effect.succeed(false),
+			setAutomatedSecurityFixes: () => Effect.void,
+			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+			setPrivateVulnerabilityReporting: () => Effect.void,
+			getCodeScanningDefaultSetup: () => Effect.succeed({}),
+			updateCodeScanningDefaultSetup: () => Effect.void,
+			listRepoLanguages: () => Effect.succeed([]),
+			resolveTeamId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -498,6 +520,16 @@ describe("SyncEngine", () => {
 				return Effect.void;
 			},
 			deleteEnvironmentVariable: () => Effect.void,
+			getVulnerabilityAlerts: () => Effect.succeed(false),
+			setVulnerabilityAlerts: () => Effect.void,
+			getAutomatedSecurityFixes: () => Effect.succeed(false),
+			setAutomatedSecurityFixes: () => Effect.void,
+			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+			setPrivateVulnerabilityReporting: () => Effect.void,
+			getCodeScanningDefaultSetup: () => Effect.succeed({}),
+			updateCodeScanningDefaultSetup: () => Effect.void,
+			listRepoLanguages: () => Effect.succeed([]),
+			resolveTeamId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -608,6 +640,16 @@ describe("SyncEngine", () => {
 			deleteEnvironment: () => Effect.void,
 			deleteEnvironmentSecret: () => Effect.void,
 			deleteEnvironmentVariable: () => Effect.void,
+			getVulnerabilityAlerts: () => Effect.succeed(false),
+			setVulnerabilityAlerts: () => Effect.void,
+			getAutomatedSecurityFixes: () => Effect.succeed(false),
+			setAutomatedSecurityFixes: () => Effect.void,
+			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+			setPrivateVulnerabilityReporting: () => Effect.void,
+			getCodeScanningDefaultSetup: () => Effect.succeed({}),
+			updateCodeScanningDefaultSetup: () => Effect.void,
+			listRepoLanguages: () => Effect.succeed([]),
+			resolveTeamId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -646,5 +688,357 @@ describe("SyncEngine", () => {
 
 		// No cleanup should happen when noCleanup is true
 		expect(deleted).toHaveLength(0);
+	});
+
+	describe("Advanced security sync", () => {
+		it("syncs vulnerability_alerts when current state differs from desired", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				security: { oss: { vulnerability_alerts: true } },
+				groups: {
+					mygroup: { repos: ["repo-one"], security: ["oss"] },
+				},
+			});
+			const creds = makeTestCredentials();
+
+			const program = Effect.gen(function* () {
+				const engine = yield* SyncEngine;
+				return yield* engine.syncAll(config, creds, { dryRun: false, noCleanup: true, configDir: process.cwd() });
+			}).pipe(Effect.provide(testLayer));
+
+			await Effect.runPromise(program);
+
+			expect(recorder.calls()).toContainEqual({
+				method: "setVulnerabilityAlerts",
+				args: { owner: "testowner", repo: "repo-one", enabled: true },
+			});
+		});
+
+		it("syncs all three security feature toggles when configured", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				security: {
+					oss: {
+						vulnerability_alerts: true,
+						automated_security_fixes: true,
+						private_vulnerability_reporting: true,
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], security: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			const methods = recorder.calls().map((c) => c.method);
+			expect(methods).toContain("setVulnerabilityAlerts");
+			expect(methods).toContain("setAutomatedSecurityFixes");
+			expect(methods).toContain("setPrivateVulnerabilityReporting");
+		});
+
+		it("does not call security setters in dry-run mode", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				security: { oss: { vulnerability_alerts: true } },
+				groups: { mygroup: { repos: ["repo-one"], security: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: true,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			expect(recorder.calls().some((c) => c.method.startsWith("set"))).toBe(false);
+		});
+
+		it("merges multiple security groups (last write wins)", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				security: {
+					base: { vulnerability_alerts: false, automated_security_fixes: true },
+					override: { vulnerability_alerts: true },
+				},
+				groups: { mygroup: { repos: ["repo-one"], security: ["base", "override"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			expect(recorder.calls()).toContainEqual({
+				method: "setVulnerabilityAlerts",
+				args: { owner: "testowner", repo: "repo-one", enabled: true },
+			});
+			expect(recorder.calls()).toContainEqual({
+				method: "setAutomatedSecurityFixes",
+				args: { owner: "testowner", repo: "repo-one", enabled: true },
+			});
+		});
+
+		it("syncs code_scanning default setup with merged config", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				code_scanning: {
+					oss: {
+						state: "configured",
+						query_suite: "extended",
+						threat_model: "remote",
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], code_scanning: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			expect(recorder.calls()).toContainEqual(
+				expect.objectContaining({
+					method: "updateCodeScanningDefaultSetup",
+					args: expect.objectContaining({
+						owner: "testowner",
+						repo: "repo-one",
+						config: expect.objectContaining({
+							state: "configured",
+							query_suite: "extended",
+							threat_model: "remote",
+						}),
+					}),
+				}),
+			);
+		});
+
+		it("filters code_scanning languages by detected repo languages", async () => {
+			// Custom recorder with non-default listRepoLanguages
+			const recorded: Array<{ method: string; args: Record<string, unknown> }> = [];
+			const githubLayer = Layer.succeed(GitHubClient, {
+				getOwnerType: () => Effect.succeed("User" as const),
+				syncSecret: () => Effect.void,
+				syncVariable: () => Effect.void,
+				syncSettings: () => Effect.void,
+				syncRuleset: () => Effect.void,
+				listSecrets: () => Effect.succeed([]),
+				listVariables: () => Effect.succeed([]),
+				listRulesets: () => Effect.succeed([]),
+				deleteSecret: () => Effect.void,
+				deleteVariable: () => Effect.void,
+				deleteRuleset: () => Effect.void,
+				syncEnvironment: () => Effect.void,
+				syncEnvironmentSecret: () => Effect.void,
+				syncEnvironmentVariable: () => Effect.void,
+				listEnvironments: () => Effect.succeed([]),
+				listEnvironmentSecrets: () => Effect.succeed([]),
+				listEnvironmentVariables: () => Effect.succeed([]),
+				deleteEnvironment: () => Effect.void,
+				deleteEnvironmentSecret: () => Effect.void,
+				deleteEnvironmentVariable: () => Effect.void,
+				getVulnerabilityAlerts: () => Effect.succeed(false),
+				setVulnerabilityAlerts: () => Effect.void,
+				getAutomatedSecurityFixes: () => Effect.succeed(false),
+				setAutomatedSecurityFixes: () => Effect.void,
+				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+				setPrivateVulnerabilityReporting: () => Effect.void,
+				getCodeScanningDefaultSetup: () => Effect.succeed({}),
+				updateCodeScanningDefaultSetup: (owner, repo, config) => {
+					recorded.push({ method: "updateCodeScanningDefaultSetup", args: { owner, repo, config } });
+					return Effect.void;
+				},
+				listRepoLanguages: () => Effect.succeed(["TypeScript", "JavaScript"]),
+				resolveTeamId: () => Effect.succeed(0),
+			});
+
+			const opStubs = OnePasswordClientTest({});
+			const credResolverLayer = Layer.provide(CredentialResolverLive, opStubs);
+			const loggerLayer = SyncLoggerLive({ dryRun: false, logLevel: "silent" });
+			const testLayer = Layer.provideMerge(
+				SyncEngineLive,
+				Layer.merge(Layer.merge(githubLayer, credResolverLayer), loggerLayer),
+			);
+
+			const config = makeTestConfig({
+				code_scanning: {
+					oss: {
+						state: "configured",
+						languages: ["javascript-typescript", "python"],
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], code_scanning: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			expect(recorded).toHaveLength(1);
+			const config0 = recorded[0]?.args.config as { languages: string[] };
+			expect(config0.languages).toEqual(["javascript-typescript"]);
+			expect(config0.languages).not.toContain("python");
+		});
+
+		it("strips org-only security_and_analysis fields on personal accounts", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			const config = makeTestConfig({
+				settings: {
+					oss: {
+						security_and_analysis: {
+							secret_scanning: "enabled",
+							secret_scanning_delegated_bypass: "enabled",
+							delegated_bypass_reviewers: [{ team: "security-team", mode: "ALWAYS" }],
+						},
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], settings: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			const settingsCall = recorder.calls().find((c) => c.method === "syncSettings");
+			expect(settingsCall).toBeDefined();
+			const settings = settingsCall?.args.settings as { security_and_analysis?: Record<string, unknown> };
+			expect(settings.security_and_analysis).toBeDefined();
+			expect(settings.security_and_analysis?.secret_scanning).toBe("enabled");
+			// Org-only fields should have been dropped
+			expect(settings.security_and_analysis?.secret_scanning_delegated_bypass).toBeUndefined();
+			expect(settings.security_and_analysis?.delegated_bypass_reviewers).toBeUndefined();
+			// And resolveTeamId should NOT have been called
+			expect(recorder.calls().some((c) => c.method === "resolveTeamId")).toBe(false);
+		});
+
+		it("resolves team slugs to reviewer IDs on org accounts", async () => {
+			// Custom layer that returns Organization for getOwnerType and stubs resolveTeamId
+			const recorded: Array<{ method: string; args: Record<string, unknown> }> = [];
+			const githubLayer = Layer.succeed(GitHubClient, {
+				getOwnerType: () => Effect.succeed("Organization" as const),
+				syncSecret: () => Effect.void,
+				syncVariable: () => Effect.void,
+				syncSettings: (owner, repo, settings) => {
+					recorded.push({ method: "syncSettings", args: { owner, repo, settings } });
+					return Effect.void;
+				},
+				syncRuleset: () => Effect.void,
+				listSecrets: () => Effect.succeed([]),
+				listVariables: () => Effect.succeed([]),
+				listRulesets: () => Effect.succeed([]),
+				deleteSecret: () => Effect.void,
+				deleteVariable: () => Effect.void,
+				deleteRuleset: () => Effect.void,
+				syncEnvironment: () => Effect.void,
+				syncEnvironmentSecret: () => Effect.void,
+				syncEnvironmentVariable: () => Effect.void,
+				listEnvironments: () => Effect.succeed([]),
+				listEnvironmentSecrets: () => Effect.succeed([]),
+				listEnvironmentVariables: () => Effect.succeed([]),
+				deleteEnvironment: () => Effect.void,
+				deleteEnvironmentSecret: () => Effect.void,
+				deleteEnvironmentVariable: () => Effect.void,
+				getVulnerabilityAlerts: () => Effect.succeed(false),
+				setVulnerabilityAlerts: () => Effect.void,
+				getAutomatedSecurityFixes: () => Effect.succeed(false),
+				setAutomatedSecurityFixes: () => Effect.void,
+				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+				setPrivateVulnerabilityReporting: () => Effect.void,
+				getCodeScanningDefaultSetup: () => Effect.succeed({}),
+				updateCodeScanningDefaultSetup: () => Effect.void,
+				listRepoLanguages: () => Effect.succeed([]),
+				resolveTeamId: (org, slug) => {
+					recorded.push({ method: "resolveTeamId", args: { org, slug } });
+					return Effect.succeed(slug === "security-team" ? 12345 : 0);
+				},
+			});
+
+			const opStubs = OnePasswordClientTest({});
+			const credResolverLayer = Layer.provide(CredentialResolverLive, opStubs);
+			const loggerLayer = SyncLoggerLive({ dryRun: false, logLevel: "silent" });
+			const testLayer = Layer.provideMerge(
+				SyncEngineLive,
+				Layer.merge(Layer.merge(githubLayer, credResolverLayer), loggerLayer),
+			);
+
+			const config = makeTestConfig({
+				owner: "myorg",
+				settings: {
+					oss: {
+						security_and_analysis: {
+							secret_scanning_delegated_bypass: "enabled",
+							delegated_bypass_reviewers: [{ team: "security-team", mode: "ALWAYS" }, { role: "admin" }],
+						},
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], settings: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			expect(recorded.some((r) => r.method === "resolveTeamId" && r.args.slug === "security-team")).toBe(true);
+			const settingsCall = recorded.find((r) => r.method === "syncSettings");
+			expect(settingsCall).toBeDefined();
+			const settings = settingsCall?.args.settings as {
+				security_and_analysis?: { delegated_bypass_reviewers?: Array<Record<string, unknown>> };
+			};
+			const reviewers = settings.security_and_analysis?.delegated_bypass_reviewers;
+			expect(reviewers).toHaveLength(2);
+			expect(reviewers?.[0]).toMatchObject({ reviewer_id: 12345, reviewer_type: "TEAM", mode: "ALWAYS" });
+			expect(reviewers?.[1]).toMatchObject({ reviewer_id: "admin", reviewer_type: "ROLE" });
+		});
 	});
 });

--- a/package/__test__/services/SyncEngine.test.ts
+++ b/package/__test__/services/SyncEngine.test.ts
@@ -915,6 +915,80 @@ describe("SyncEngine", () => {
 			expect(config0.languages).not.toContain("python");
 		});
 
+		it("always passes 'actions' language through regardless of detected repo languages", async () => {
+			const recorded: Array<{ method: string; args: Record<string, unknown> }> = [];
+			const githubLayer = Layer.succeed(GitHubClient, {
+				getOwnerType: () => Effect.succeed("User" as const),
+				syncSecret: () => Effect.void,
+				syncVariable: () => Effect.void,
+				syncSettings: () => Effect.void,
+				syncRuleset: () => Effect.void,
+				listSecrets: () => Effect.succeed([]),
+				listVariables: () => Effect.succeed([]),
+				listRulesets: () => Effect.succeed([]),
+				deleteSecret: () => Effect.void,
+				deleteVariable: () => Effect.void,
+				deleteRuleset: () => Effect.void,
+				syncEnvironment: () => Effect.void,
+				syncEnvironmentSecret: () => Effect.void,
+				syncEnvironmentVariable: () => Effect.void,
+				listEnvironments: () => Effect.succeed([]),
+				listEnvironmentSecrets: () => Effect.succeed([]),
+				listEnvironmentVariables: () => Effect.succeed([]),
+				deleteEnvironment: () => Effect.void,
+				deleteEnvironmentSecret: () => Effect.void,
+				deleteEnvironmentVariable: () => Effect.void,
+				getVulnerabilityAlerts: () => Effect.succeed(false),
+				setVulnerabilityAlerts: () => Effect.void,
+				getAutomatedSecurityFixes: () => Effect.succeed(false),
+				setAutomatedSecurityFixes: () => Effect.void,
+				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
+				setPrivateVulnerabilityReporting: () => Effect.void,
+				getCodeScanningDefaultSetup: () => Effect.succeed({}),
+				updateCodeScanningDefaultSetup: (owner, repo, config) => {
+					recorded.push({ method: "updateCodeScanningDefaultSetup", args: { owner, repo, config } });
+					return Effect.void;
+				},
+				// listLanguages does not report "Actions" — actions must pass through anyway
+				listRepoLanguages: () => Effect.succeed([]),
+				resolveTeamId: () => Effect.succeed(0),
+			});
+
+			const opStubs = OnePasswordClientTest({});
+			const credResolverLayer = Layer.provide(CredentialResolverLive, opStubs);
+			const loggerLayer = SyncLoggerLive({ dryRun: false, logLevel: "silent" });
+			const testLayer = Layer.provideMerge(
+				SyncEngineLive,
+				Layer.merge(Layer.merge(githubLayer, credResolverLayer), loggerLayer),
+			);
+
+			const config = makeTestConfig({
+				code_scanning: {
+					oss: {
+						state: "configured",
+						languages: ["actions", "python"],
+					},
+				},
+				groups: { mygroup: { repos: ["repo-one"], code_scanning: ["oss"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			const config0 = recorded[0]?.args.config as { languages: string[] };
+			expect(config0.languages).toContain("actions");
+			expect(config0.languages).not.toContain("python");
+		});
+
 		it("strips org-only security_and_analysis fields on personal accounts", async () => {
 			const { testLayer, recorder } = buildTestLayer();
 			const config = makeTestConfig({

--- a/package/__test__/services/SyncEngine.test.ts
+++ b/package/__test__/services/SyncEngine.test.ts
@@ -360,6 +360,7 @@ describe("SyncEngine", () => {
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
+			resolveRoleId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -446,6 +447,7 @@ describe("SyncEngine", () => {
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
+			resolveRoleId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -527,6 +529,7 @@ describe("SyncEngine", () => {
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
+			resolveRoleId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -646,6 +649,7 @@ describe("SyncEngine", () => {
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
+			resolveRoleId: () => Effect.succeed(0),
 		});
 
 		const opStubs = OnePasswordClientTest({});
@@ -901,6 +905,7 @@ describe("SyncEngine", () => {
 				},
 				listRepoLanguages: () => Effect.succeed(["TypeScript", "JavaScript"]),
 				resolveTeamId: () => Effect.succeed(0),
+				resolveRoleId: () => Effect.succeed(0),
 			});
 
 			const opStubs = OnePasswordClientTest({});
@@ -975,6 +980,7 @@ describe("SyncEngine", () => {
 				// listLanguages does not report "Actions" — actions must pass through anyway
 				listRepoLanguages: () => Effect.succeed([]),
 				resolveTeamId: () => Effect.succeed(0),
+				resolveRoleId: () => Effect.succeed(0),
 			});
 
 			const opStubs = OnePasswordClientTest({});
@@ -1090,6 +1096,10 @@ describe("SyncEngine", () => {
 					recorded.push({ method: "resolveTeamId", args: { org, slug } });
 					return Effect.succeed(slug === "security-team" ? 12345 : 0);
 				},
+				resolveRoleId: (org, name) => {
+					recorded.push({ method: "resolveRoleId", args: { org, name } });
+					return Effect.succeed(name === "all_repo_admin" ? 8136 : 0);
+				},
 			});
 
 			const opStubs = OnePasswordClientTest({});
@@ -1106,7 +1116,7 @@ describe("SyncEngine", () => {
 					oss: {
 						security_and_analysis: {
 							secret_scanning_delegated_bypass: "enabled",
-							delegated_bypass_reviewers: [{ team: "security-team", mode: "ALWAYS" }, { role: "admin" }],
+							delegated_bypass_reviewers: [{ team: "security-team", mode: "ALWAYS" }, { role: "all_repo_admin" }],
 						},
 					},
 				},
@@ -1126,6 +1136,7 @@ describe("SyncEngine", () => {
 			);
 
 			expect(recorded.some((r) => r.method === "resolveTeamId" && r.args.slug === "security-team")).toBe(true);
+			expect(recorded.some((r) => r.method === "resolveRoleId" && r.args.name === "all_repo_admin")).toBe(true);
 			const settingsCall = recorded.find((r) => r.method === "syncSettings");
 			expect(settingsCall).toBeDefined();
 			const settings = settingsCall?.args.settings as {
@@ -1134,7 +1145,7 @@ describe("SyncEngine", () => {
 			const reviewers = settings.security_and_analysis?.delegated_bypass_reviewers;
 			expect(reviewers).toHaveLength(2);
 			expect(reviewers?.[0]).toMatchObject({ reviewer_id: 12345, reviewer_type: "TEAM", mode: "ALWAYS" });
-			expect(reviewers?.[1]).toMatchObject({ reviewer_id: "admin", reviewer_type: "ROLE" });
+			expect(reviewers?.[1]).toMatchObject({ reviewer_id: 8136, reviewer_type: "ROLE" });
 		});
 	});
 });

--- a/package/__test__/services/SyncEngine.test.ts
+++ b/package/__test__/services/SyncEngine.test.ts
@@ -357,7 +357,6 @@ describe("SyncEngine", () => {
 			setAutomatedSecurityFixes: () => Effect.void,
 			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 			setPrivateVulnerabilityReporting: () => Effect.void,
-			getCodeScanningDefaultSetup: () => Effect.succeed({}),
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
@@ -444,7 +443,6 @@ describe("SyncEngine", () => {
 			setAutomatedSecurityFixes: () => Effect.void,
 			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 			setPrivateVulnerabilityReporting: () => Effect.void,
-			getCodeScanningDefaultSetup: () => Effect.succeed({}),
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
@@ -526,7 +524,6 @@ describe("SyncEngine", () => {
 			setAutomatedSecurityFixes: () => Effect.void,
 			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 			setPrivateVulnerabilityReporting: () => Effect.void,
-			getCodeScanningDefaultSetup: () => Effect.succeed({}),
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
@@ -646,7 +643,6 @@ describe("SyncEngine", () => {
 			setAutomatedSecurityFixes: () => Effect.void,
 			getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 			setPrivateVulnerabilityReporting: () => Effect.void,
-			getCodeScanningDefaultSetup: () => Effect.succeed({}),
 			updateCodeScanningDefaultSetup: () => Effect.void,
 			listRepoLanguages: () => Effect.succeed([]),
 			resolveTeamId: () => Effect.succeed(0),
@@ -799,6 +795,35 @@ describe("SyncEngine", () => {
 			});
 		});
 
+		it("skips security sync when merged config violates the cross-field invariant", async () => {
+			const { testLayer, recorder } = buildTestLayer();
+			// Each group is individually valid; the merge produces a contradiction
+			// (automated_security_fixes = true + vulnerability_alerts = false).
+			const config = makeTestConfig({
+				security: {
+					base: { vulnerability_alerts: false },
+					override: { automated_security_fixes: true },
+				},
+				groups: { mygroup: { repos: ["repo-one"], security: ["base", "override"] } },
+			});
+			const creds = makeTestCredentials();
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const engine = yield* SyncEngine;
+					return yield* engine.syncAll(config, creds, {
+						dryRun: false,
+						noCleanup: true,
+						configDir: process.cwd(),
+					});
+				}).pipe(Effect.provide(testLayer)),
+			);
+
+			const calls = recorder.calls();
+			expect(calls.some((c) => c.method === "setAutomatedSecurityFixes")).toBe(false);
+			expect(calls.some((c) => c.method === "setVulnerabilityAlerts")).toBe(false);
+		});
+
 		it("syncs code_scanning default setup with merged config", async () => {
 			const { testLayer, recorder } = buildTestLayer();
 			const config = makeTestConfig({
@@ -870,7 +895,6 @@ describe("SyncEngine", () => {
 				setAutomatedSecurityFixes: () => Effect.void,
 				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 				setPrivateVulnerabilityReporting: () => Effect.void,
-				getCodeScanningDefaultSetup: () => Effect.succeed({}),
 				updateCodeScanningDefaultSetup: (owner, repo, config) => {
 					recorded.push({ method: "updateCodeScanningDefaultSetup", args: { owner, repo, config } });
 					return Effect.void;
@@ -944,7 +968,6 @@ describe("SyncEngine", () => {
 				setAutomatedSecurityFixes: () => Effect.void,
 				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 				setPrivateVulnerabilityReporting: () => Effect.void,
-				getCodeScanningDefaultSetup: () => Effect.succeed({}),
 				updateCodeScanningDefaultSetup: (owner, repo, config) => {
 					recorded.push({ method: "updateCodeScanningDefaultSetup", args: { owner, repo, config } });
 					return Effect.void;
@@ -1061,7 +1084,6 @@ describe("SyncEngine", () => {
 				setAutomatedSecurityFixes: () => Effect.void,
 				getPrivateVulnerabilityReporting: () => Effect.succeed(false),
 				setPrivateVulnerabilityReporting: () => Effect.void,
-				getCodeScanningDefaultSetup: () => Effect.succeed({}),
 				updateCodeScanningDefaultSetup: () => Effect.void,
 				listRepoLanguages: () => Effect.succeed([]),
 				resolveTeamId: (org, slug) => {

--- a/package/package.json
+++ b/package/package.json
@@ -50,9 +50,9 @@
 	},
 	"dependencies": {
 		"@1password/sdk": "^0.4.0",
-		"@effect/cli": "^0.75.1",
-		"@effect/platform": "^0.96.0",
-		"@effect/platform-node": "^0.106.0",
+		"@effect/cli": "catalog:silk",
+		"@effect/platform": "catalog:silk",
+		"@effect/platform-node": "catalog:silk",
 		"@octokit/rest": "^22.0.1",
 		"blakejs": "^1.2.1",
 		"effect": "^3.21.1",
@@ -64,7 +64,7 @@
 		"@savvy-web/rslib-builder": "^0.20.2",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
-		"ajv": "^8.18.0",
+		"ajv": "^8.20.0",
 		"tsx": "catalog:silk",
 		"typescript": "catalog:silk"
 	},

--- a/package/schemas/reposets.config.schema.json
+++ b/package/schemas/reposets.config.schema.json
@@ -1382,7 +1382,7 @@
 				}
 			},
 			"additionalProperties": false,
-			"description": "CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202; reposets fires-and-forgets by default and polls in verbose mode.",
+			"description": "CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202 Accepted and configures asynchronously; reposets sends the request and does not poll for completion.",
 			"title": "Code scanning group",
 			"x-tombi-table-keys-order": "schema",
 			"x-taplo": {

--- a/package/schemas/reposets.config.schema.json
+++ b/package/schemas/reposets.config.schema.json
@@ -64,18 +64,36 @@
 			"title": "Environments",
 			"x-tombi-additional-key-label": "environment_name"
 		},
+		"security": {
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/SecurityGroup"
+			},
+			"description": "Named security groups for vulnerability alerts, automated security fixes, and private vulnerability reporting",
+			"title": "Security groups",
+			"x-tombi-additional-key-label": "security_group"
+		},
+		"code_scanning": {
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/$defs/CodeScanningGroup"
+			},
+			"description": "Named code scanning groups for CodeQL default setup configuration",
+			"title": "Code scanning groups",
+			"x-tombi-additional-key-label": "code_scanning_group"
+		},
 		"groups": {
 			"type": "object",
 			"additionalProperties": {
 				"$ref": "#/$defs/Group"
 			},
-			"description": "Named groups of repositories with their settings, secrets, variables, rulesets, and environment assignments",
+			"description": "Named groups of repositories with their settings, secrets, variables, rulesets, environments, security, and code scanning assignments",
 			"title": "Groups",
 			"x-tombi-additional-key-label": "group_name"
 		}
 	},
 	"additionalProperties": false,
-	"description": "Configuration for syncing GitHub repository settings, secrets, variables, rulesets, and deployment environments",
+	"description": "Configuration for syncing GitHub repository settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup",
 	"title": "reposets Configuration",
 	"x-tombi-table-keys-order": "schema",
 	"x-taplo": {
@@ -192,6 +210,9 @@
 					"type": "boolean",
 					"description": "Require contributors to sign off on web-based commits",
 					"title": "Require commit signoff"
+				},
+				"security_and_analysis": {
+					"$ref": "#/$defs/SecurityAndAnalysis"
 				}
 			},
 			"additionalProperties": {},
@@ -203,6 +224,126 @@
 					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
 				}
 			}
+		},
+		"SecurityAndAnalysis": {
+			"type": "object",
+			"properties": {
+				"advanced_security": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(GHAS-licensed) Master toggle for GitHub Advanced Security features. Free on public repos; requires a GHAS license on private repos.",
+					"title": "GitHub Advanced Security"
+				},
+				"code_security": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(GHAS-licensed) Toggle GitHub Code Security functionality.",
+					"title": "GitHub Code Security"
+				},
+				"secret_scanning": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "Detect exposed credentials and sensitive data committed to the repository.",
+					"title": "Secret scanning"
+				},
+				"secret_scanning_push_protection": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "Block git pushes that contain detected secrets.",
+					"title": "Secret scanning push protection"
+				},
+				"secret_scanning_ai_detection": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(GHAS-licensed) AI-powered detection of generic secrets beyond standard provider patterns.",
+					"title": "Secret scanning AI detection"
+				},
+				"secret_scanning_non_provider_patterns": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(GHAS-licensed) Detect custom secret patterns beyond the standard provider list.",
+					"title": "Secret scanning non-provider patterns"
+				},
+				"secret_scanning_delegated_alert_dismissal": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(org-only) Allow delegated dismissal of secret scanning alerts.",
+					"title": "Delegated alert dismissal"
+				},
+				"secret_scanning_delegated_bypass": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "(org-only) Allow delegated approval of secret scanning push protection bypass requests.",
+					"title": "Delegated push protection bypass"
+				},
+				"delegated_bypass_reviewers": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/DelegatedBypassReviewer"
+					},
+					"description": "(org-only) Reviewers authorized to approve push protection bypass requests. Each entry must specify a team slug or role name.",
+					"title": "Delegated bypass reviewers"
+				},
+				"dependabot_security_updates": {
+					"type": "string",
+					"enum": ["enabled", "disabled"],
+					"description": "Automatically open pull requests to patch known dependency vulnerabilities.",
+					"title": "Dependabot security updates"
+				}
+			},
+			"additionalProperties": false,
+			"description": "GitHub repository security_and_analysis fields applied via the same PATCH /repos call as other settings. (GHAS-licensed) fields require a GHAS license on private repos; (org-only) fields are silently skipped on personal repos.",
+			"title": "Security and analysis",
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+				}
+			}
+		},
+		"DelegatedBypassReviewer": {
+			"anyOf": [
+				{
+					"type": "object",
+					"required": ["team"],
+					"properties": {
+						"team": {
+							"type": "string",
+							"description": "GitHub team slug (e.g., \"security-team\"); resolved to numeric reviewer_id at sync time",
+							"title": "Team slug",
+							"examples": ["security-team"]
+						},
+						"mode": {
+							"$ref": "#/$defs/DelegatedBypassReviewerMode"
+						}
+					},
+					"additionalProperties": false
+				},
+				{
+					"type": "object",
+					"required": ["role"],
+					"properties": {
+						"role": {
+							"type": "string",
+							"description": "Repository role name (e.g., \"admin\", \"maintain\")",
+							"title": "Repository role",
+							"examples": ["admin", "maintain"]
+						},
+						"mode": {
+							"$ref": "#/$defs/DelegatedBypassReviewerMode"
+						}
+					},
+					"additionalProperties": false
+				}
+			],
+			"description": "A reviewer who can approve secret-scanning push-protection bypass requests. Must specify exactly one of team or role.",
+			"title": "Delegated bypass reviewer"
+		},
+		"DelegatedBypassReviewerMode": {
+			"type": "string",
+			"enum": ["ALWAYS", "EXEMPT"],
+			"description": "ALWAYS: reviewer is always required to approve bypass; EXEMPT: reviewer can bypass without review",
+			"title": "Delegated bypass reviewer mode"
 		},
 		"SecretGroup": {
 			"anyOf": [
@@ -1181,6 +1322,105 @@
 			"description": "A custom branch or tag pattern that deployments are allowed from",
 			"title": "Deployment branch policy"
 		},
+		"SecurityGroup": {
+			"type": "object",
+			"properties": {
+				"vulnerability_alerts": {
+					"type": "boolean",
+					"description": "Enable Dependabot vulnerability alerts (PUT/DELETE /repos/{o}/{r}/vulnerability-alerts).",
+					"title": "Vulnerability alerts"
+				},
+				"automated_security_fixes": {
+					"type": "boolean",
+					"description": "Enable Dependabot security pull requests (PUT/DELETE /repos/{o}/{r}/automated-security-fixes). Requires vulnerability_alerts to also be enabled.",
+					"title": "Automated security fixes"
+				},
+				"private_vulnerability_reporting": {
+					"type": "boolean",
+					"description": "Enable the private vulnerability reporting inbox (PUT/DELETE /repos/{o}/{r}/private-vulnerability-reporting).",
+					"title": "Private vulnerability reporting"
+				}
+			},
+			"additionalProperties": false,
+			"description": "Toggles for repository-level security features that have dedicated PUT/DELETE endpoints (vulnerability alerts, automated security fixes, private vulnerability reporting). Omitted keys are left untouched.",
+			"title": "Security group",
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+				}
+			}
+		},
+		"CodeScanningGroup": {
+			"type": "object",
+			"properties": {
+				"state": {
+					"$ref": "#/$defs/CodeScanningState"
+				},
+				"languages": {
+					"type": "array",
+					"items": {
+						"$ref": "#/$defs/CodeScanningLanguage"
+					},
+					"description": "CodeQL languages to analyze. Languages not detected in the repository are skipped with a warning at sync time.",
+					"title": "Languages",
+					"examples": [["javascript-typescript", "python"]]
+				},
+				"query_suite": {
+					"$ref": "#/$defs/CodeScanningQuerySuite"
+				},
+				"threat_model": {
+					"$ref": "#/$defs/CodeScanningThreatModel"
+				},
+				"runner_type": {
+					"$ref": "#/$defs/CodeScanningRunnerType"
+				},
+				"runner_label": {
+					"type": "string",
+					"description": "Self-hosted runner label. Required when runner_type = \"labeled\".",
+					"title": "Runner label"
+				}
+			},
+			"additionalProperties": false,
+			"description": "CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202; reposets fires-and-forgets by default and polls in verbose mode.",
+			"title": "Code scanning group",
+			"x-tombi-table-keys-order": "schema",
+			"x-taplo": {
+				"links": {
+					"key": "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md"
+				}
+			}
+		},
+		"CodeScanningState": {
+			"type": "string",
+			"enum": ["configured", "not-configured"],
+			"description": "\"configured\" enables CodeQL default setup; \"not-configured\" disables it.",
+			"title": "Default setup state"
+		},
+		"CodeScanningLanguage": {
+			"type": "string",
+			"enum": ["actions", "c-cpp", "csharp", "go", "java-kotlin", "javascript-typescript", "python", "ruby", "swift"],
+			"description": "Languages supported by GitHub code scanning default setup. Note: this is narrower than the CodeQL analyzer (Rust is supported by CodeQL but not by default setup).",
+			"title": "CodeQL default-setup language"
+		},
+		"CodeScanningQuerySuite": {
+			"type": "string",
+			"enum": ["default", "extended"],
+			"description": "\"default\" runs the standard query set; \"extended\" includes additional security queries.",
+			"title": "Query suite"
+		},
+		"CodeScanningThreatModel": {
+			"type": "string",
+			"enum": ["remote", "remote_and_local"],
+			"description": "\"remote\" analyzes network sources only; \"remote_and_local\" also includes filesystem and environment access.",
+			"title": "Threat model"
+		},
+		"CodeScanningRunnerType": {
+			"type": "string",
+			"enum": ["standard", "labeled"],
+			"description": "\"standard\" uses GitHub-hosted runners; \"labeled\" uses runners matching runner_label.",
+			"title": "Runner type"
+		},
 		"Group": {
 			"type": "object",
 			"required": ["repos"],
@@ -1239,6 +1479,24 @@
 					"description": "Names of rulesets to apply to these repos",
 					"title": "Rulesets",
 					"examples": [["workflow", "release"]]
+				},
+				"security": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Names of security groups (vulnerability alerts, automated security fixes, private vulnerability reporting) to apply to these repos",
+					"title": "Security groups",
+					"examples": [["oss-defaults"]]
+				},
+				"code_scanning": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Names of code_scanning groups (CodeQL default setup) to apply to these repos",
+					"title": "Code scanning groups",
+					"examples": [["oss-defaults"]]
 				},
 				"cleanup": {
 					"$ref": "#/$defs/Cleanup"

--- a/package/schemas/reposets.config.schema.json
+++ b/package/schemas/reposets.config.schema.json
@@ -325,9 +325,9 @@
 					"properties": {
 						"role": {
 							"type": "string",
-							"description": "Repository role name (e.g., \"admin\", \"maintain\")",
-							"title": "Repository role",
-							"examples": ["admin", "maintain"]
+							"description": "Organization role name as defined in `GET /orgs/{org}/organization-roles` (e.g., \"all_repo_admin\", \"security_manager\"). Resolved to the numeric role ID at sync time.",
+							"title": "Organization role name",
+							"examples": ["all_repo_admin", "all_repo_maintain", "security_manager"]
 						},
 						"mode": {
 							"$ref": "#/$defs/DelegatedBypassReviewerMode"

--- a/package/src/cli/commands/doctor.ts
+++ b/package/src/cli/commands/doctor.ts
@@ -17,6 +17,8 @@ const KNOWN_CONFIG_KEYS = new Set([
 	"variables",
 	"rulesets",
 	"environments",
+	"security",
+	"code_scanning",
 	"groups",
 ]);
 const KNOWN_GROUP_KEYS = new Set([
@@ -28,6 +30,8 @@ const KNOWN_GROUP_KEYS = new Set([
 	"variables",
 	"rulesets",
 	"environments",
+	"security",
+	"code_scanning",
 	"cleanup",
 ]);
 const KNOWN_CLEANUP_KEYS = new Set(["secrets", "variables", "rulesets", "environments"]);
@@ -170,7 +174,13 @@ export const doctorCommand = Command.make("doctor", { config: configOption }, ({
 		yield* Effect.log("  Repository permissions > Secrets (Read and write) -- Actions secrets");
 		yield* Effect.log("  Repository permissions > Variables (Read and write) -- Actions variables");
 		yield* Effect.log("  Repository permissions > Environments (Read and write) -- environment sync");
+		yield* Effect.log("  Repository permissions > Code scanning alerts (Read and write) -- code_scanning sync");
+		yield* Effect.log("  Repository permissions > Dependabot alerts (Read and write) -- security feature sync");
+		yield* Effect.log(
+			"  Repository permissions > Secret scanning alerts (Read and write) -- secret scanning delegation",
+		);
 		yield* Effect.log("  Account permissions > GPG keys (Read and write) -- secrets encryption key");
+		yield* Effect.log("  Organization permissions > Members (Read) -- resolve team slugs (org-level only)");
 
 		if (warnings === 0) {
 			yield* Effect.log("\nNo unknown keys detected.");

--- a/package/src/cli/commands/init.ts
+++ b/package/src/cli/commands/init.ts
@@ -55,6 +55,35 @@ const CONFIG_TEMPLATE = `# reposets configuration
 # [[rulesets.default-branch.rules]]
 # type = "deletion"
 
+# --- Advanced security ---
+# Nested inside a settings group (folded into the same PATCH /repos call).
+# Some fields are GHAS-licensed and only work on public repos or
+# private repos with a GHAS subscription. Org-only fields are silently
+# skipped on personal accounts.
+#
+# [settings.defaults.security_and_analysis]
+# secret_scanning = "enabled"
+# secret_scanning_push_protection = "enabled"
+# dependabot_security_updates = "enabled"
+
+# --- Security feature toggles ---
+# Dedicated PUT/DELETE endpoints; omit a key to leave it untouched.
+#
+# [security.oss-defaults]
+# vulnerability_alerts = true
+# automated_security_fixes = true
+# private_vulnerability_reporting = true
+
+# --- CodeQL default setup ---
+# Applies via PATCH /repos/{o}/{r}/code-scanning/default-setup.
+# Languages not detected in the repo are skipped with a warning.
+#
+# [code_scanning.oss-defaults]
+# state = "configured"
+# languages = ["javascript-typescript", "python"]
+# query_suite = "extended"
+# threat_model = "remote"
+
 # --- Cleanup defaults ---
 # [cleanup]
 # secrets = false
@@ -68,6 +97,8 @@ const CONFIG_TEMPLATE = `# reposets configuration
 # secrets = { actions = ["from-files", "from-creds"] }
 # variables = { actions = ["turbo", "bot"] }
 # rulesets = ["default-branch"]
+# security = ["oss-defaults"]
+# code_scanning = ["oss-defaults"]
 `;
 
 const CREDENTIALS_TEMPLATE = `# reposets credentials (keep this file private)

--- a/package/src/cli/commands/list.ts
+++ b/package/src/cli/commands/list.ts
@@ -75,6 +75,12 @@ export const listCommand = Command.make("list", { config: configOption }, ({ con
 			if (group.rulesets?.length) {
 				yield* Effect.log(`  rulesets: ${group.rulesets.join(", ")}`);
 			}
+			if (group.security?.length) {
+				yield* Effect.log(`  security: ${group.security.join(", ")}`);
+			}
+			if (group.code_scanning?.length) {
+				yield* Effect.log(`  code_scanning: ${group.code_scanning.join(", ")}`);
+			}
 			if (group.credentials) {
 				yield* Effect.log(`  credentials: ${group.credentials}`);
 			}

--- a/package/src/schemas/config.ts
+++ b/package/src/schemas/config.ts
@@ -116,6 +116,21 @@ export const GroupSchema = Schema.Struct({
 			examples: [["workflow", "release"]],
 		}),
 	),
+	security: Schema.optional(
+		Schema.Array(Schema.String).annotations({
+			title: "Security groups",
+			description:
+				"Names of security groups (vulnerability alerts, automated security fixes, private vulnerability reporting) to apply to these repos",
+			examples: [["oss-defaults"]],
+		}),
+	),
+	code_scanning: Schema.optional(
+		Schema.Array(Schema.String).annotations({
+			title: "Code scanning groups",
+			description: "Names of code_scanning groups (CodeQL default setup) to apply to these repos",
+			examples: [["oss-defaults"]],
+		}),
+	),
 	cleanup: Schema.optional(CleanupSchema),
 }).annotations({
 	identifier: "Group",
@@ -155,6 +170,120 @@ const MergeCommitMessageSchema = Schema.Literal("PR_BODY", "PR_TITLE", "BLANK").
 	description:
 		"Default message body for merge commits: PR_BODY uses the pull request body, PR_TITLE uses the PR title, BLANK leaves it empty",
 });
+
+const SecurityAndAnalysisStatusSchema = Schema.Literal("enabled", "disabled").annotations({
+	identifier: "SecurityAndAnalysisStatus",
+	title: "Security feature status",
+	description: 'Whether the security feature is "enabled" or "disabled"',
+});
+
+const DelegatedBypassReviewerModeSchema = Schema.Literal("ALWAYS", "EXEMPT").annotations({
+	identifier: "DelegatedBypassReviewerMode",
+	title: "Delegated bypass reviewer mode",
+	description: "ALWAYS: reviewer is always required to approve bypass; EXEMPT: reviewer can bypass without review",
+});
+
+const DelegatedBypassReviewerSchema = Schema.Union(
+	Schema.Struct({
+		team: Schema.String.annotations({
+			title: "Team slug",
+			description: 'GitHub team slug (e.g., "security-team"); resolved to numeric reviewer_id at sync time',
+			examples: ["security-team"],
+		}),
+		mode: Schema.optional(DelegatedBypassReviewerModeSchema),
+	}),
+	Schema.Struct({
+		role: Schema.String.annotations({
+			title: "Repository role",
+			description: 'Repository role name (e.g., "admin", "maintain")',
+			examples: ["admin", "maintain"],
+		}),
+		mode: Schema.optional(DelegatedBypassReviewerModeSchema),
+	}),
+).annotations({
+	identifier: "DelegatedBypassReviewer",
+	title: "Delegated bypass reviewer",
+	description:
+		"A reviewer who can approve secret-scanning push-protection bypass requests. Must specify exactly one of team or role.",
+});
+
+const SecurityAndAnalysisSchema = Schema.Struct({
+	advanced_security: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "GitHub Advanced Security",
+			description:
+				"(GHAS-licensed) Master toggle for GitHub Advanced Security features. Free on public repos; requires a GHAS license on private repos.",
+		}),
+	),
+	code_security: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "GitHub Code Security",
+			description: "(GHAS-licensed) Toggle GitHub Code Security functionality.",
+		}),
+	),
+	secret_scanning: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Secret scanning",
+			description: "Detect exposed credentials and sensitive data committed to the repository.",
+		}),
+	),
+	secret_scanning_push_protection: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Secret scanning push protection",
+			description: "Block git pushes that contain detected secrets.",
+		}),
+	),
+	secret_scanning_ai_detection: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Secret scanning AI detection",
+			description: "(GHAS-licensed) AI-powered detection of generic secrets beyond standard provider patterns.",
+		}),
+	),
+	secret_scanning_non_provider_patterns: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Secret scanning non-provider patterns",
+			description: "(GHAS-licensed) Detect custom secret patterns beyond the standard provider list.",
+		}),
+	),
+	secret_scanning_delegated_alert_dismissal: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Delegated alert dismissal",
+			description: "(org-only) Allow delegated dismissal of secret scanning alerts.",
+		}),
+	),
+	secret_scanning_delegated_bypass: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Delegated push protection bypass",
+			description: "(org-only) Allow delegated approval of secret scanning push protection bypass requests.",
+		}),
+	),
+	delegated_bypass_reviewers: Schema.optional(
+		Schema.Array(DelegatedBypassReviewerSchema).annotations({
+			title: "Delegated bypass reviewers",
+			description:
+				"(org-only) Reviewers authorized to approve push protection bypass requests. Each entry must specify a team slug or role name.",
+		}),
+	),
+	dependabot_security_updates: Schema.optional(
+		SecurityAndAnalysisStatusSchema.annotations({
+			title: "Dependabot security updates",
+			description: "Automatically open pull requests to patch known dependency vulnerabilities.",
+		}),
+	),
+}).annotations({
+	identifier: "SecurityAndAnalysis",
+	title: "Security and analysis",
+	description:
+		"GitHub repository security_and_analysis fields applied via the same PATCH /repos call as other settings. (GHAS-licensed) fields require a GHAS license on private repos; (org-only) fields are silently skipped on personal repos.",
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
+});
+
+export type SecurityAndAnalysis = typeof SecurityAndAnalysisSchema.Type;
 
 const SettingsGroupSchema = Schema.Struct(
 	{
@@ -252,6 +381,7 @@ const SettingsGroupSchema = Schema.Struct(
 				description: "Require contributors to sign off on web-based commits",
 			}),
 		),
+		security_and_analysis: Schema.optional(SecurityAndAnalysisSchema),
 	},
 	{ key: Schema.String, value: Jsonifiable },
 ).annotations({
@@ -266,6 +396,118 @@ const SettingsGroupSchema = Schema.Struct(
 		}),
 	},
 });
+
+export const SecurityGroupSchema = Schema.Struct({
+	vulnerability_alerts: Schema.optional(
+		Schema.Boolean.annotations({
+			title: "Vulnerability alerts",
+			description: "Enable Dependabot vulnerability alerts (PUT/DELETE /repos/{o}/{r}/vulnerability-alerts).",
+		}),
+	),
+	automated_security_fixes: Schema.optional(
+		Schema.Boolean.annotations({
+			title: "Automated security fixes",
+			description:
+				"Enable Dependabot security pull requests (PUT/DELETE /repos/{o}/{r}/automated-security-fixes). Requires vulnerability_alerts to also be enabled.",
+		}),
+	),
+	private_vulnerability_reporting: Schema.optional(
+		Schema.Boolean.annotations({
+			title: "Private vulnerability reporting",
+			description:
+				"Enable the private vulnerability reporting inbox (PUT/DELETE /repos/{o}/{r}/private-vulnerability-reporting).",
+		}),
+	),
+}).annotations({
+	identifier: "SecurityGroup",
+	title: "Security group",
+	description:
+		"Toggles for repository-level security features that have dedicated PUT/DELETE endpoints (vulnerability alerts, automated security fixes, private vulnerability reporting). Omitted keys are left untouched.",
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
+});
+
+export type SecurityGroup = typeof SecurityGroupSchema.Type;
+
+export const CodeScanningLanguageSchema = Schema.Literal(
+	"actions",
+	"c-cpp",
+	"csharp",
+	"go",
+	"java-kotlin",
+	"javascript-typescript",
+	"python",
+	"ruby",
+	"swift",
+).annotations({
+	identifier: "CodeScanningLanguage",
+	title: "CodeQL default-setup language",
+	description:
+		"Languages supported by GitHub code scanning default setup. Note: this is narrower than the CodeQL analyzer (Rust is supported by CodeQL but not by default setup).",
+});
+
+const CodeScanningStateSchema = Schema.Literal("configured", "not-configured").annotations({
+	identifier: "CodeScanningState",
+	title: "Default setup state",
+	description: '"configured" enables CodeQL default setup; "not-configured" disables it.',
+});
+
+const CodeScanningQuerySuiteSchema = Schema.Literal("default", "extended").annotations({
+	identifier: "CodeScanningQuerySuite",
+	title: "Query suite",
+	description: '"default" runs the standard query set; "extended" includes additional security queries.',
+});
+
+const CodeScanningThreatModelSchema = Schema.Literal("remote", "remote_and_local").annotations({
+	identifier: "CodeScanningThreatModel",
+	title: "Threat model",
+	description:
+		'"remote" analyzes network sources only; "remote_and_local" also includes filesystem and environment access.',
+});
+
+const CodeScanningRunnerTypeSchema = Schema.Literal("standard", "labeled").annotations({
+	identifier: "CodeScanningRunnerType",
+	title: "Runner type",
+	description: '"standard" uses GitHub-hosted runners; "labeled" uses runners matching runner_label.',
+});
+
+export const CodeScanningGroupSchema = Schema.Struct({
+	state: Schema.optional(CodeScanningStateSchema),
+	languages: Schema.optional(
+		Schema.Array(CodeScanningLanguageSchema).annotations({
+			title: "Languages",
+			description:
+				"CodeQL languages to analyze. Languages not detected in the repository are skipped with a warning at sync time.",
+			examples: [["javascript-typescript", "python"]],
+		}),
+	),
+	query_suite: Schema.optional(CodeScanningQuerySuiteSchema),
+	threat_model: Schema.optional(CodeScanningThreatModelSchema),
+	runner_type: Schema.optional(CodeScanningRunnerTypeSchema),
+	runner_label: Schema.optional(
+		Schema.String.annotations({
+			title: "Runner label",
+			description: 'Self-hosted runner label. Required when runner_type = "labeled".',
+		}),
+	),
+}).annotations({
+	identifier: "CodeScanningGroup",
+	title: "Code scanning group",
+	description:
+		"CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202; reposets fires-and-forgets by default and polls in verbose mode.",
+	jsonSchema: {
+		...tombi({ tableKeysOrder: "schema" }),
+		...taplo({
+			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+		}),
+	},
+});
+
+export type CodeScanningGroup = typeof CodeScanningGroupSchema.Type;
 
 export const LogLevelSchema = Schema.Literal("silent", "info", "verbose", "debug").annotations({
 	identifier: "LogLevel",
@@ -334,20 +576,43 @@ export const ConfigSchema = Schema.Struct({
 		}),
 		{ default: () => ({}) },
 	),
+	security: Schema.optionalWith(
+		Schema.Record({
+			key: Schema.String,
+			value: SecurityGroupSchema,
+		}).annotations({
+			title: "Security groups",
+			description:
+				"Named security groups for vulnerability alerts, automated security fixes, and private vulnerability reporting",
+			jsonSchema: tombi({ additionalKeyLabel: "security_group" }),
+		}),
+		{ default: () => ({}) },
+	),
+	code_scanning: Schema.optionalWith(
+		Schema.Record({
+			key: Schema.String,
+			value: CodeScanningGroupSchema,
+		}).annotations({
+			title: "Code scanning groups",
+			description: "Named code scanning groups for CodeQL default setup configuration",
+			jsonSchema: tombi({ additionalKeyLabel: "code_scanning_group" }),
+		}),
+		{ default: () => ({}) },
+	),
 	groups: Schema.Record({
 		key: Schema.String,
 		value: GroupSchema,
 	}).annotations({
 		title: "Groups",
 		description:
-			"Named groups of repositories with their settings, secrets, variables, rulesets, and environment assignments",
+			"Named groups of repositories with their settings, secrets, variables, rulesets, environments, security, and code scanning assignments",
 		jsonSchema: tombi({ additionalKeyLabel: "group_name" }),
 	}),
 }).annotations({
 	identifier: "Config",
 	title: "reposets Configuration",
 	description:
-		"Configuration for syncing GitHub repository settings, secrets, variables, rulesets, and deployment environments",
+		"Configuration for syncing GitHub repository settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup",
 	jsonSchema: {
 		...tombi({ tableKeysOrder: "schema" }),
 		...taplo({

--- a/package/src/schemas/config.ts
+++ b/package/src/schemas/config.ts
@@ -194,9 +194,10 @@ const DelegatedBypassReviewerSchema = Schema.Union(
 	}),
 	Schema.Struct({
 		role: Schema.String.annotations({
-			title: "Repository role",
-			description: 'Repository role name (e.g., "admin", "maintain")',
-			examples: ["admin", "maintain"],
+			title: "Organization role name",
+			description:
+				'Organization role name as defined in `GET /orgs/{org}/organization-roles` (e.g., "all_repo_admin", "security_manager"). Resolved to the numeric role ID at sync time.',
+			examples: ["all_repo_admin", "all_repo_maintain", "security_manager"],
 		}),
 		mode: Schema.optional(DelegatedBypassReviewerModeSchema),
 	}),

--- a/package/src/schemas/config.ts
+++ b/package/src/schemas/config.ts
@@ -418,18 +418,26 @@ export const SecurityGroupSchema = Schema.Struct({
 				"Enable the private vulnerability reporting inbox (PUT/DELETE /repos/{o}/{r}/private-vulnerability-reporting).",
 		}),
 	),
-}).annotations({
-	identifier: "SecurityGroup",
-	title: "Security group",
-	description:
-		"Toggles for repository-level security features that have dedicated PUT/DELETE endpoints (vulnerability alerts, automated security fixes, private vulnerability reporting). Omitted keys are left untouched.",
-	jsonSchema: {
-		...tombi({ tableKeysOrder: "schema" }),
-		...taplo({
-			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+})
+	.pipe(
+		Schema.filter((group) => !(group.automated_security_fixes === true && group.vulnerability_alerts === false), {
+			identifier: "SecurityGroup",
+			message: () =>
+				"automated_security_fixes = true requires vulnerability_alerts to be enabled (or omitted to leave the existing setting in place)",
 		}),
-	},
-});
+	)
+	.annotations({
+		identifier: "SecurityGroup",
+		title: "Security group",
+		description:
+			"Toggles for repository-level security features that have dedicated PUT/DELETE endpoints (vulnerability alerts, automated security fixes, private vulnerability reporting). Omitted keys are left untouched.",
+		jsonSchema: {
+			...tombi({ tableKeysOrder: "schema" }),
+			...taplo({
+				links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+			}),
+		},
+	});
 
 export type SecurityGroup = typeof SecurityGroupSchema.Type;
 
@@ -494,18 +502,25 @@ export const CodeScanningGroupSchema = Schema.Struct({
 			description: 'Self-hosted runner label. Required when runner_type = "labeled".',
 		}),
 	),
-}).annotations({
-	identifier: "CodeScanningGroup",
-	title: "Code scanning group",
-	description:
-		"CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202 Accepted and configures asynchronously; reposets sends the request and does not poll for completion.",
-	jsonSchema: {
-		...tombi({ tableKeysOrder: "schema" }),
-		...taplo({
-			links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+})
+	.pipe(
+		Schema.filter((group) => group.runner_type !== "labeled" || group.runner_label !== undefined, {
+			identifier: "CodeScanningGroup",
+			message: () => 'runner_label is required when runner_type = "labeled"',
 		}),
-	},
-});
+	)
+	.annotations({
+		identifier: "CodeScanningGroup",
+		title: "Code scanning group",
+		description:
+			"CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202 Accepted and configures asynchronously; reposets sends the request and does not poll for completion.",
+		jsonSchema: {
+			...tombi({ tableKeysOrder: "schema" }),
+			...taplo({
+				links: { key: "https://github.com/spencerbeggs/reposets/blob/main/docs/configuration.md" },
+			}),
+		},
+	});
 
 export type CodeScanningGroup = typeof CodeScanningGroupSchema.Type;
 

--- a/package/src/schemas/config.ts
+++ b/package/src/schemas/config.ts
@@ -498,7 +498,7 @@ export const CodeScanningGroupSchema = Schema.Struct({
 	identifier: "CodeScanningGroup",
 	title: "Code scanning group",
 	description:
-		"CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202; reposets fires-and-forgets by default and polls in verbose mode.",
+		"CodeQL default setup configuration applied via PATCH /repos/{o}/{r}/code-scanning/default-setup. The endpoint returns 202 Accepted and configures asynchronously; reposets sends the request and does not poll for completion.",
 	jsonSchema: {
 		...tombi({ tableKeysOrder: "schema" }),
 		...taplo({

--- a/package/src/services/ConfigFiles.ts
+++ b/package/src/services/ConfigFiles.ts
@@ -40,6 +40,8 @@ export function validateConfigRefs(config: Config): Effect.Effect<Config, Config
 	const definedVariables = new Set(Object.keys(config.variables));
 	const definedRulesets = new Set(Object.keys(config.rulesets));
 	const definedEnvironments = new Set(Object.keys(config.environments));
+	const definedSecurity = new Set(Object.keys(config.security));
+	const definedCodeScanning = new Set(Object.keys(config.code_scanning));
 
 	for (const [groupName, group] of Object.entries(config.groups)) {
 		// Check settings references
@@ -65,6 +67,24 @@ export function validateConfigRefs(config: Config): Effect.Effect<Config, Config
 			for (const ref of group.environments) {
 				if (!definedEnvironments.has(ref)) {
 					errors.push(`group '${groupName}': unknown environment '${ref}'`);
+				}
+			}
+		}
+
+		// Check security references
+		if (group.security) {
+			for (const ref of group.security) {
+				if (!definedSecurity.has(ref)) {
+					errors.push(`group '${groupName}': unknown security group '${ref}'`);
+				}
+			}
+		}
+
+		// Check code_scanning references
+		if (group.code_scanning) {
+			for (const ref of group.code_scanning) {
+				if (!definedCodeScanning.has(ref)) {
+					errors.push(`group '${groupName}': unknown code_scanning group '${ref}'`);
 				}
 			}
 		}

--- a/package/src/services/GitHubClient.ts
+++ b/package/src/services/GitHubClient.ts
@@ -2,9 +2,19 @@ import { Octokit } from "@octokit/rest";
 import { Context, Effect, Layer } from "effect";
 import { GitHubApiError } from "../errors.js";
 import { encryptSecret } from "../lib/crypto.js";
+import type { CodeScanningGroup } from "../schemas/config.js";
 import type { RulesetPayload } from "../schemas/ruleset.js";
 
 export type SecretScope = "actions" | "dependabot" | "codespaces";
+
+export interface CodeScanningDefaultSetup {
+	state?: "configured" | "not-configured" | undefined;
+	languages?: ReadonlyArray<string> | undefined;
+	query_suite?: "default" | "extended" | undefined;
+	threat_model?: "remote" | "remote_and_local" | undefined;
+	runner_type?: "standard" | "labeled" | undefined;
+	runner_label?: string | undefined;
+}
 
 export interface SecretInfo {
 	name: string;
@@ -130,12 +140,91 @@ export interface GitHubClientService {
 		envName: string,
 		name: string,
 	) => Effect.Effect<void, GitHubApiError>;
+
+	readonly getVulnerabilityAlerts: (owner: string, repo: string) => Effect.Effect<boolean, GitHubApiError>;
+
+	readonly setVulnerabilityAlerts: (
+		owner: string,
+		repo: string,
+		enabled: boolean,
+	) => Effect.Effect<void, GitHubApiError>;
+
+	readonly getAutomatedSecurityFixes: (owner: string, repo: string) => Effect.Effect<boolean, GitHubApiError>;
+
+	readonly setAutomatedSecurityFixes: (
+		owner: string,
+		repo: string,
+		enabled: boolean,
+	) => Effect.Effect<void, GitHubApiError>;
+
+	readonly getPrivateVulnerabilityReporting: (owner: string, repo: string) => Effect.Effect<boolean, GitHubApiError>;
+
+	readonly setPrivateVulnerabilityReporting: (
+		owner: string,
+		repo: string,
+		enabled: boolean,
+	) => Effect.Effect<void, GitHubApiError>;
+
+	readonly getCodeScanningDefaultSetup: (
+		owner: string,
+		repo: string,
+	) => Effect.Effect<CodeScanningDefaultSetup, GitHubApiError>;
+
+	readonly updateCodeScanningDefaultSetup: (
+		owner: string,
+		repo: string,
+		config: CodeScanningGroup,
+	) => Effect.Effect<void, GitHubApiError>;
+
+	readonly listRepoLanguages: (owner: string, repo: string) => Effect.Effect<ReadonlyArray<string>, GitHubApiError>;
+
+	readonly resolveTeamId: (org: string, slug: string) => Effect.Effect<number, GitHubApiError>;
 }
 
 export class GitHubClient extends Context.Tag("GitHubClient")<GitHubClient, GitHubClientService>() {}
 
 /** Settings fields that are only valid for organization-owned repositories. */
 export const ORG_ONLY_SETTINGS = new Set(["allow_forking"]);
+
+/**
+ * Fields in the user-facing security_and_analysis block that GitHub's API
+ * accepts as `{ status: "enabled" | "disabled" }`. The value as stored in
+ * config is the literal string; we wrap it before sending.
+ */
+const SAA_STATUS_FIELDS = new Set([
+	"advanced_security",
+	"code_security",
+	"secret_scanning",
+	"secret_scanning_push_protection",
+	"secret_scanning_ai_detection",
+	"secret_scanning_non_provider_patterns",
+	"secret_scanning_delegated_alert_dismissal",
+	"secret_scanning_delegated_bypass",
+	"dependabot_security_updates",
+]);
+
+/**
+ * Translate the user-facing security_and_analysis config block into the
+ * shape GitHub expects on `PATCH /repos/{o}/{r}`. Reviewer entries are
+ * expected to already have a numeric `reviewer_id` and `reviewer_type`
+ * (resolution from team slugs happens in the SyncEngine).
+ */
+export function transformSecurityAndAnalysis(value: unknown): Record<string, unknown> | undefined {
+	if (value === null || typeof value !== "object") return undefined;
+	const input = value as Record<string, unknown>;
+	const out: Record<string, unknown> = {};
+
+	for (const [key, raw] of Object.entries(input)) {
+		if (raw === undefined) continue;
+		if (SAA_STATUS_FIELDS.has(key) && (raw === "enabled" || raw === "disabled")) {
+			out[key] = { status: raw };
+		} else if (key === "delegated_bypass_reviewers" && Array.isArray(raw)) {
+			out.secret_scanning_delegated_bypass_options = { reviewers: raw };
+		}
+	}
+
+	return Object.keys(out).length > 0 ? out : undefined;
+}
 
 /**
  * Settings fields only available via the GraphQL `updateRepository` mutation.
@@ -166,6 +255,7 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 			}
 
 			const ownerTypeCache = new Map<string, OwnerType>();
+			const teamIdCache = new Map<string, number>();
 
 			return {
 				getOwnerType(owner) {
@@ -243,6 +333,11 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 							const graphqlInput: Record<string, unknown> = {};
 
 							for (const [key, value] of Object.entries(settings)) {
+								if (key === "security_and_analysis") {
+									const saa = transformSecurityAndAnalysis(value);
+									if (saa !== undefined) restSettings.security_and_analysis = saa;
+									continue;
+								}
 								const graphqlField = GRAPHQL_SETTINGS[key];
 								if (graphqlField !== undefined) {
 									graphqlInput[graphqlField] = value;
@@ -522,6 +617,147 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 						catch: wrapError,
 					});
 				},
+
+				getVulnerabilityAlerts(owner, repo) {
+					return Effect.tryPromise({
+						try: async () => {
+							try {
+								await octokit.request("GET /repos/{owner}/{repo}/vulnerability-alerts", { owner, repo });
+								return true;
+							} catch (error) {
+								const status = (error as { status?: number }).status;
+								if (status === 404) return false;
+								throw error;
+							}
+						},
+						catch: wrapError,
+					});
+				},
+
+				setVulnerabilityAlerts(owner, repo, enabled) {
+					return Effect.tryPromise({
+						try: async () => {
+							if (enabled) {
+								await octokit.request("PUT /repos/{owner}/{repo}/vulnerability-alerts", { owner, repo });
+							} else {
+								await octokit.request("DELETE /repos/{owner}/{repo}/vulnerability-alerts", { owner, repo });
+							}
+						},
+						catch: wrapError,
+					});
+				},
+
+				getAutomatedSecurityFixes(owner, repo) {
+					return Effect.tryPromise({
+						try: async () => {
+							const { data } = await octokit.request("GET /repos/{owner}/{repo}/automated-security-fixes", {
+								owner,
+								repo,
+							});
+							return Boolean((data as { enabled?: boolean }).enabled);
+						},
+						catch: wrapError,
+					});
+				},
+
+				setAutomatedSecurityFixes(owner, repo, enabled) {
+					return Effect.tryPromise({
+						try: async () => {
+							if (enabled) {
+								await octokit.request("PUT /repos/{owner}/{repo}/automated-security-fixes", { owner, repo });
+							} else {
+								await octokit.request("DELETE /repos/{owner}/{repo}/automated-security-fixes", { owner, repo });
+							}
+						},
+						catch: wrapError,
+					});
+				},
+
+				getPrivateVulnerabilityReporting(owner, repo) {
+					return Effect.tryPromise({
+						try: async () => {
+							const { data } = await octokit.request("GET /repos/{owner}/{repo}/private-vulnerability-reporting", {
+								owner,
+								repo,
+							});
+							return Boolean((data as { enabled?: boolean }).enabled);
+						},
+						catch: wrapError,
+					});
+				},
+
+				setPrivateVulnerabilityReporting(owner, repo, enabled) {
+					return Effect.tryPromise({
+						try: async () => {
+							if (enabled) {
+								await octokit.request("PUT /repos/{owner}/{repo}/private-vulnerability-reporting", { owner, repo });
+							} else {
+								await octokit.request("DELETE /repos/{owner}/{repo}/private-vulnerability-reporting", {
+									owner,
+									repo,
+								});
+							}
+						},
+						catch: wrapError,
+					});
+				},
+
+				getCodeScanningDefaultSetup(owner, repo) {
+					return Effect.tryPromise({
+						try: async () => {
+							const { data } = await octokit.request("GET /repos/{owner}/{repo}/code-scanning/default-setup", {
+								owner,
+								repo,
+							});
+							return data as CodeScanningDefaultSetup;
+						},
+						catch: wrapError,
+					});
+				},
+
+				updateCodeScanningDefaultSetup(owner, repo, config) {
+					return Effect.tryPromise({
+						try: async () => {
+							const body: Record<string, unknown> = {};
+							if (config.state !== undefined) body.state = config.state;
+							if (config.languages !== undefined) body.languages = [...config.languages];
+							if (config.query_suite !== undefined) body.query_suite = config.query_suite;
+							if (config.threat_model !== undefined) body.threat_model = config.threat_model;
+							if (config.runner_type !== undefined) body.runner_type = config.runner_type;
+							if (config.runner_label !== undefined) body.runner_label = config.runner_label;
+							await octokit.request("PATCH /repos/{owner}/{repo}/code-scanning/default-setup", {
+								owner,
+								repo,
+								...body,
+							});
+						},
+						catch: wrapError,
+					});
+				},
+
+				listRepoLanguages(owner, repo) {
+					return Effect.tryPromise({
+						try: async () => {
+							const { data } = await octokit.repos.listLanguages({ owner, repo });
+							return Object.keys(data);
+						},
+						catch: wrapError,
+					});
+				},
+
+				resolveTeamId(org, slug) {
+					return Effect.tryPromise({
+						try: async () => {
+							const cacheKey = `${org}:${slug}`;
+							const cached = teamIdCache.get(cacheKey);
+							if (cached !== undefined) return cached;
+							const { data } = await octokit.teams.getByName({ org, team_slug: slug });
+							teamIdCache.set(cacheKey, data.id);
+							return data.id;
+						},
+						catch: wrapError,
+					});
+				},
 			};
 		})(),
 	);
@@ -628,6 +864,51 @@ export function GitHubClientTest(): { layer: Layer.Layer<GitHubClient>; calls: (
 		deleteEnvironmentVariable(owner, repo, envName, name) {
 			recorded.push({ method: "deleteEnvironmentVariable", args: { owner, repo, envName, name } });
 			return Effect.void;
+		},
+
+		getVulnerabilityAlerts(_owner, _repo) {
+			return Effect.succeed(false);
+		},
+
+		setVulnerabilityAlerts(owner, repo, enabled) {
+			recorded.push({ method: "setVulnerabilityAlerts", args: { owner, repo, enabled } });
+			return Effect.void;
+		},
+
+		getAutomatedSecurityFixes(_owner, _repo) {
+			return Effect.succeed(false);
+		},
+
+		setAutomatedSecurityFixes(owner, repo, enabled) {
+			recorded.push({ method: "setAutomatedSecurityFixes", args: { owner, repo, enabled } });
+			return Effect.void;
+		},
+
+		getPrivateVulnerabilityReporting(_owner, _repo) {
+			return Effect.succeed(false);
+		},
+
+		setPrivateVulnerabilityReporting(owner, repo, enabled) {
+			recorded.push({ method: "setPrivateVulnerabilityReporting", args: { owner, repo, enabled } });
+			return Effect.void;
+		},
+
+		getCodeScanningDefaultSetup(_owner, _repo) {
+			return Effect.succeed({});
+		},
+
+		updateCodeScanningDefaultSetup(owner, repo, config) {
+			recorded.push({ method: "updateCodeScanningDefaultSetup", args: { owner, repo, config } });
+			return Effect.void;
+		},
+
+		listRepoLanguages(_owner, _repo) {
+			return Effect.succeed([]);
+		},
+
+		resolveTeamId(org, slug) {
+			recorded.push({ method: "resolveTeamId", args: { org, slug } });
+			return Effect.succeed(0);
 		},
 	});
 

--- a/package/src/services/GitHubClient.ts
+++ b/package/src/services/GitHubClient.ts
@@ -7,15 +7,6 @@ import type { RulesetPayload } from "../schemas/ruleset.js";
 
 export type SecretScope = "actions" | "dependabot" | "codespaces";
 
-export interface CodeScanningDefaultSetup {
-	state?: "configured" | "not-configured" | undefined;
-	languages?: ReadonlyArray<string> | undefined;
-	query_suite?: "default" | "extended" | undefined;
-	threat_model?: "remote" | "remote_and_local" | undefined;
-	runner_type?: "standard" | "labeled" | undefined;
-	runner_label?: string | undefined;
-}
-
 export interface SecretInfo {
 	name: string;
 }
@@ -164,11 +155,6 @@ export interface GitHubClientService {
 		repo: string,
 		enabled: boolean,
 	) => Effect.Effect<void, GitHubApiError>;
-
-	readonly getCodeScanningDefaultSetup: (
-		owner: string,
-		repo: string,
-	) => Effect.Effect<CodeScanningDefaultSetup, GitHubApiError>;
 
 	readonly updateCodeScanningDefaultSetup: (
 		owner: string,
@@ -704,19 +690,6 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 					});
 				},
 
-				getCodeScanningDefaultSetup(owner, repo) {
-					return Effect.tryPromise({
-						try: async () => {
-							const { data } = await octokit.request("GET /repos/{owner}/{repo}/code-scanning/default-setup", {
-								owner,
-								repo,
-							});
-							return data as CodeScanningDefaultSetup;
-						},
-						catch: wrapError,
-					});
-				},
-
 				updateCodeScanningDefaultSetup(owner, repo, config) {
 					return Effect.tryPromise({
 						try: async () => {
@@ -893,10 +866,6 @@ export function GitHubClientTest(): { layer: Layer.Layer<GitHubClient>; calls: (
 		setPrivateVulnerabilityReporting(owner, repo, enabled) {
 			recorded.push({ method: "setPrivateVulnerabilityReporting", args: { owner, repo, enabled } });
 			return Effect.void;
-		},
-
-		getCodeScanningDefaultSetup(_owner, _repo) {
-			return Effect.succeed({});
 		},
 
 		updateCodeScanningDefaultSetup(owner, repo, config) {

--- a/package/src/services/GitHubClient.ts
+++ b/package/src/services/GitHubClient.ts
@@ -165,6 +165,8 @@ export interface GitHubClientService {
 	readonly listRepoLanguages: (owner: string, repo: string) => Effect.Effect<ReadonlyArray<string>, GitHubApiError>;
 
 	readonly resolveTeamId: (org: string, slug: string) => Effect.Effect<number, GitHubApiError>;
+
+	readonly resolveRoleId: (org: string, name: string) => Effect.Effect<number, GitHubApiError>;
 }
 
 export class GitHubClient extends Context.Tag("GitHubClient")<GitHubClient, GitHubClientService>() {}
@@ -244,6 +246,7 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 
 			const ownerTypeCache = new Map<string, OwnerType>();
 			const teamIdCache = new Map<string, number>();
+			const roleIdCache = new Map<string, number>();
 
 			return {
 				getOwnerType(owner) {
@@ -733,6 +736,27 @@ export function GitHubClientLive(token: string): Layer.Layer<GitHubClient> {
 						catch: wrapError,
 					});
 				},
+
+				resolveRoleId(org, name) {
+					return Effect.tryPromise({
+						try: async () => {
+							const cacheKey = `${org}:${name}`;
+							const cached = roleIdCache.get(cacheKey);
+							if (cached !== undefined) return cached;
+							const { data } = await octokit.request("GET /orgs/{org}/organization-roles", { org });
+							const roles = (data as { roles?: ReadonlyArray<{ id: number; name: string }> }).roles ?? [];
+							const role = roles.find((r) => r.name === name);
+							if (!role) {
+								throw new Error(
+									`organization role '${name}' not found in '${org}' (available: ${roles.map((r) => r.name).join(", ") || "none"})`,
+								);
+							}
+							roleIdCache.set(cacheKey, role.id);
+							return role.id;
+						},
+						catch: wrapError,
+					});
+				},
 			};
 		})(),
 	);
@@ -879,6 +903,11 @@ export function GitHubClientTest(): { layer: Layer.Layer<GitHubClient>; calls: (
 
 		resolveTeamId(org, slug) {
 			recorded.push({ method: "resolveTeamId", args: { org, slug } });
+			return Effect.succeed(0);
+		},
+
+		resolveRoleId(org, name) {
+			recorded.push({ method: "resolveRoleId", args: { org, name } });
 			return Effect.succeed(0);
 		},
 	});

--- a/package/src/services/GitHubClient.ts
+++ b/package/src/services/GitHubClient.ts
@@ -218,7 +218,9 @@ export function transformSecurityAndAnalysis(value: unknown): Record<string, unk
 		if (raw === undefined) continue;
 		if (SAA_STATUS_FIELDS.has(key) && (raw === "enabled" || raw === "disabled")) {
 			out[key] = { status: raw };
-		} else if (key === "delegated_bypass_reviewers" && Array.isArray(raw)) {
+		} else if (key === "delegated_bypass_reviewers" && Array.isArray(raw) && raw.length > 0) {
+			// Empty arrays are treated as "no change" — sending { reviewers: [] }
+			// would be rejected by GitHub when delegated bypass is enabled.
 			out.secret_scanning_delegated_bypass_options = { reviewers: raw };
 		}
 	}

--- a/package/src/services/SyncEngine.ts
+++ b/package/src/services/SyncEngine.ts
@@ -3,7 +3,7 @@ import { isAbsolute, resolve } from "node:path";
 import { Context, Effect, Layer } from "effect";
 import { ResolveError, SyncError } from "../errors.js";
 import type { CleanupScope, SecretGroup } from "../schemas/common.js";
-import type { Config } from "../schemas/config.js";
+import type { CodeScanningGroup, Config, SecurityAndAnalysis, SecurityGroup } from "../schemas/config.js";
 import type { Credentials } from "../schemas/credentials.js";
 import type { Ruleset, RulesetPayload } from "../schemas/ruleset.js";
 import { buildRulesetPayload } from "../schemas/ruleset.js";
@@ -11,6 +11,33 @@ import { CredentialResolver } from "./CredentialResolver.js";
 import type { OwnerType, SecretScope } from "./GitHubClient.js";
 import { GitHubClient, ORG_ONLY_SETTINGS } from "./GitHubClient.js";
 import { SyncLogger } from "./SyncLogger.js";
+
+/** Fields that GitHub only accepts on org-owned repositories. */
+const ORG_ONLY_SAA_FIELDS = new Set([
+	"secret_scanning_delegated_alert_dismissal",
+	"secret_scanning_delegated_bypass",
+	"delegated_bypass_reviewers",
+]);
+
+/**
+ * Map GitHub repo language names (as returned by listLanguages) to the
+ * code scanning default-setup language enum. Unmapped languages are dropped
+ * from the detected set (callers warn about configured languages that don't
+ * appear in the mapped detected set).
+ */
+const REPO_LANG_TO_CODEQL: Record<string, string> = {
+	JavaScript: "javascript-typescript",
+	TypeScript: "javascript-typescript",
+	C: "c-cpp",
+	"C++": "c-cpp",
+	"C#": "csharp",
+	Go: "go",
+	Java: "java-kotlin",
+	Kotlin: "java-kotlin",
+	Python: "python",
+	Ruby: "ruby",
+	Swift: "swift",
+};
 
 interface SyncOptions {
 	readonly dryRun: boolean;
@@ -109,6 +136,46 @@ function groupEntryNames(group: SecretGroup): string[] {
 	if ("value" in group) return Object.keys(group.value);
 	if ("resolved" in group) return Object.keys(group.resolved);
 	return [];
+}
+
+/** Last-write-wins merge of security_and_analysis blocks across setting groups. */
+function mergeSecurityAndAnalysis(
+	blocks: ReadonlyArray<SecurityAndAnalysis | undefined>,
+): SecurityAndAnalysis | undefined {
+	const merged: Record<string, unknown> = {};
+	let hasAny = false;
+	for (const block of blocks) {
+		if (!block) continue;
+		hasAny = true;
+		for (const [key, value] of Object.entries(block)) {
+			if (value !== undefined) merged[key] = value;
+		}
+	}
+	return hasAny ? (merged as SecurityAndAnalysis) : undefined;
+}
+
+/** Last-write-wins merge of SecurityGroup toggles across referenced groups. */
+function mergeSecurityGroups(groups: ReadonlyArray<SecurityGroup | undefined>): SecurityGroup {
+	const merged: Record<string, boolean> = {};
+	for (const group of groups) {
+		if (!group) continue;
+		for (const [key, value] of Object.entries(group)) {
+			if (typeof value === "boolean") merged[key] = value;
+		}
+	}
+	return merged as SecurityGroup;
+}
+
+/** Last-write-wins merge of CodeScanningGroup configs across referenced groups. */
+function mergeCodeScanningGroups(groups: ReadonlyArray<CodeScanningGroup | undefined>): CodeScanningGroup {
+	const merged: Record<string, unknown> = {};
+	for (const group of groups) {
+		if (!group) continue;
+		for (const [key, value] of Object.entries(group)) {
+			if (value !== undefined) merged[key] = value;
+		}
+	}
+	return merged as CodeScanningGroup;
 }
 
 export const SyncEngineLive = Layer.effect(
@@ -281,9 +348,15 @@ export const SyncEngineLive = Layer.effect(
 						const settingGroupRefs = group.settings ?? [];
 						const mergedSettings: Record<string, unknown> = {};
 						const skippedSettings: string[] = [];
+						const saaBlocks: Array<SecurityAndAnalysis | undefined> = [];
 						for (const ref of settingGroupRefs) {
 							const settingGroup = config.settings[ref];
-							if (settingGroup) Object.assign(mergedSettings, settingGroup);
+							if (settingGroup) {
+								// Pull the security_and_analysis block aside; merge separately
+								const { security_and_analysis, ...rest } = settingGroup;
+								Object.assign(mergedSettings, rest);
+								saaBlocks.push(security_and_analysis);
+							}
 						}
 						// Strip org-only settings for personal accounts
 						if (ownerType === "User") {
@@ -294,6 +367,70 @@ export const SyncEngineLive = Layer.effect(
 								}
 							}
 						}
+
+						// Merge security_and_analysis, drop org-only fields on personal repos,
+						// resolve team slugs to numeric reviewer IDs, and inject the resolved
+						// block back into mergedSettings.
+						const mergedSAA = mergeSecurityAndAnalysis(saaBlocks);
+						const skippedSAA: string[] = [];
+						if (mergedSAA) {
+							const saaOut: Record<string, unknown> = { ...mergedSAA };
+							if (ownerType === "User") {
+								for (const key of ORG_ONLY_SAA_FIELDS) {
+									if (key in saaOut) {
+										delete saaOut[key];
+										skippedSAA.push(key);
+									}
+								}
+							} else {
+								// Resolve team slugs to numeric reviewer IDs for org-owned repos.
+								const reviewers = saaOut.delegated_bypass_reviewers;
+								if (Array.isArray(reviewers)) {
+									const resolved: Array<Record<string, unknown>> = [];
+									for (const reviewer of reviewers as ReadonlyArray<Record<string, unknown>>) {
+										if (typeof reviewer.team === "string") {
+											const teamId = yield* github.resolveTeamId(owner, reviewer.team).pipe(
+												Effect.catchTag("GitHubApiError", (err) =>
+													Effect.gen(function* () {
+														yield* logger.syncError(`resolve team '${reviewer.team}'`, err.message);
+														return undefined;
+													}),
+												),
+											);
+											if (teamId !== undefined) {
+												const entry: Record<string, unknown> = {
+													reviewer_id: teamId,
+													reviewer_type: "TEAM",
+												};
+												if (reviewer.mode !== undefined) entry.mode = reviewer.mode;
+												resolved.push(entry);
+											}
+										} else if (typeof reviewer.role === "string") {
+											const entry: Record<string, unknown> = {
+												reviewer_id: reviewer.role,
+												reviewer_type: "ROLE",
+											};
+											if (reviewer.mode !== undefined) entry.mode = reviewer.mode;
+											resolved.push(entry);
+										}
+									}
+									saaOut.delegated_bypass_reviewers = resolved;
+								}
+							}
+							if (Object.keys(saaOut).length > 0) {
+								mergedSettings.security_and_analysis = saaOut;
+							}
+						}
+
+						// Merge security and code_scanning groups (group-scoped)
+						const securityGroupRefs = group.security ?? [];
+						const mergedSecurity = mergeSecurityGroups(securityGroupRefs.map((ref) => config.security[ref]));
+						const codeScanningRefs = group.code_scanning ?? [];
+						const mergedCodeScanning = mergeCodeScanningGroups(
+							codeScanningRefs.map((ref) => config.code_scanning[ref]),
+						);
+						const hasSecurity = Object.keys(mergedSecurity).length > 0;
+						const hasCodeScanning = Object.keys(mergedCodeScanning).length > 0;
 						const hasSecrets = secretScopes.some((s) => (resolvedSecrets.get(s)?.size ?? 0) > 0);
 						const hasVariables = resolvedVariables.size > 0;
 						const hasRulesets = rulesetMap.size > 0;
@@ -323,6 +460,8 @@ export const SyncEngineLive = Layer.effect(
 								!hasEnvironments &&
 								!hasEnvSecrets &&
 								!hasEnvVariables &&
+								!hasSecurity &&
+								!hasCodeScanning &&
 								!hasCleanup
 							) {
 								yield* logger.repoSkip(owner, repoName, "no changes configured");
@@ -343,6 +482,130 @@ export const SyncEngineLive = Layer.effect(
 								// Warn about skipped org-only settings
 								for (const key of skippedSettings) {
 									yield* logger.syncOperation("skip", "setting", key, "(org-only, owner is a personal account)");
+								}
+								for (const key of skippedSAA) {
+									yield* logger.syncOperation(
+										"skip",
+										"security_and_analysis",
+										key,
+										"(org-only, owner is a personal account)",
+									);
+								}
+
+								// Sync security features (vulnerability_alerts, automated_security_fixes,
+								// private_vulnerability_reporting). Diff against current state and only
+								// apply when the configured value differs.
+								if (hasSecurity) {
+									if (mergedSecurity.vulnerability_alerts !== undefined) {
+										const desired = mergedSecurity.vulnerability_alerts;
+										const current = yield* github.getVulnerabilityAlerts(owner, repoName).pipe(
+											Effect.catchTag("GitHubApiError", (err) =>
+												Effect.gen(function* () {
+													yield* logger.syncError("get vulnerability_alerts", err.message);
+													return desired;
+												}),
+											),
+										);
+										if (current !== desired) {
+											yield* logger.syncOperation("sync", "vulnerability_alerts", desired ? "enable" : "disable");
+											yield* github
+												.setVulnerabilityAlerts(owner, repoName, desired)
+												.pipe(
+													Effect.catchTag("GitHubApiError", (err) =>
+														logger.syncError("vulnerability_alerts", err.message),
+													),
+												);
+										}
+									}
+									if (mergedSecurity.automated_security_fixes !== undefined) {
+										const desired = mergedSecurity.automated_security_fixes;
+										const current = yield* github.getAutomatedSecurityFixes(owner, repoName).pipe(
+											Effect.catchTag("GitHubApiError", (err) =>
+												Effect.gen(function* () {
+													yield* logger.syncError("get automated_security_fixes", err.message);
+													return desired;
+												}),
+											),
+										);
+										if (current !== desired) {
+											yield* logger.syncOperation("sync", "automated_security_fixes", desired ? "enable" : "disable");
+											yield* github
+												.setAutomatedSecurityFixes(owner, repoName, desired)
+												.pipe(
+													Effect.catchTag("GitHubApiError", (err) =>
+														logger.syncError("automated_security_fixes", err.message),
+													),
+												);
+										}
+									}
+									if (mergedSecurity.private_vulnerability_reporting !== undefined) {
+										const desired = mergedSecurity.private_vulnerability_reporting;
+										const current = yield* github.getPrivateVulnerabilityReporting(owner, repoName).pipe(
+											Effect.catchTag("GitHubApiError", (err) =>
+												Effect.gen(function* () {
+													yield* logger.syncError("get private_vulnerability_reporting", err.message);
+													return desired;
+												}),
+											),
+										);
+										if (current !== desired) {
+											yield* logger.syncOperation(
+												"sync",
+												"private_vulnerability_reporting",
+												desired ? "enable" : "disable",
+											);
+											yield* github
+												.setPrivateVulnerabilityReporting(owner, repoName, desired)
+												.pipe(
+													Effect.catchTag("GitHubApiError", (err) =>
+														logger.syncError("private_vulnerability_reporting", err.message),
+													),
+												);
+										}
+									}
+								}
+
+								// Sync code scanning default setup. Filter configured languages by
+								// what GitHub detects in the repo; warn (don't fail) for missing.
+								if (hasCodeScanning) {
+									let desiredConfig: CodeScanningGroup = mergedCodeScanning;
+									if (mergedCodeScanning.languages !== undefined) {
+										const detected = yield* github.listRepoLanguages(owner, repoName).pipe(
+											Effect.catchTag("GitHubApiError", (err) =>
+												Effect.gen(function* () {
+													yield* logger.syncError("list repo languages", err.message);
+													return [] as ReadonlyArray<string>;
+												}),
+											),
+										);
+										const detectedCodeQL = new Set<string>();
+										for (const lang of detected) {
+											const mapped = REPO_LANG_TO_CODEQL[lang];
+											if (mapped) detectedCodeQL.add(mapped);
+										}
+										const filtered: Array<(typeof mergedCodeScanning.languages)[number]> = [];
+										for (const lang of mergedCodeScanning.languages) {
+											if (lang === "actions" || detectedCodeQL.has(lang)) {
+												filtered.push(lang);
+											} else {
+												yield* logger.syncOperation(
+													"skip",
+													"code_scanning language",
+													lang,
+													"(not detected in repository)",
+												);
+											}
+										}
+										desiredConfig = { ...mergedCodeScanning, languages: filtered };
+									}
+									yield* logger.syncOperation("sync", "code_scanning", desiredConfig.state ?? "default-setup");
+									yield* github
+										.updateCodeScanningDefaultSetup(owner, repoName, desiredConfig)
+										.pipe(
+											Effect.catchTag("GitHubApiError", (err) =>
+												logger.syncError("code_scanning default setup", err.message),
+											),
+										);
 								}
 
 								// Sync environments (before secrets/variables)
@@ -428,6 +691,13 @@ export const SyncEngineLive = Layer.effect(
 							}
 
 							// Info-tier summaries
+							if (hasSecurity) {
+								const securityCount = Object.values(mergedSecurity).filter((v) => v !== undefined).length;
+								yield* logger.syncSummary("security feature", securityCount, "");
+							}
+							if (hasCodeScanning) {
+								yield* logger.syncSummary("code scanning", 1, mergedCodeScanning.state ?? "applied");
+							}
 							if (hasEnvironments) {
 								yield* logger.syncSummary("environment", envRefs.length, "");
 							}

--- a/package/src/services/SyncEngine.ts
+++ b/package/src/services/SyncEngine.ts
@@ -585,6 +585,8 @@ export const SyncEngineLive = Layer.effect(
 										}
 										const filtered: Array<(typeof mergedCodeScanning.languages)[number]> = [];
 										for (const lang of mergedCodeScanning.languages) {
+											// `actions` analyses workflow YAML rather than a repo language;
+											// listLanguages never reports it, so always pass it through.
 											if (lang === "actions" || detectedCodeQL.has(lang)) {
 												filtered.push(lang);
 											} else {

--- a/package/src/services/SyncEngine.ts
+++ b/package/src/services/SyncEngine.ts
@@ -406,12 +406,22 @@ export const SyncEngineLive = Layer.effect(
 												resolved.push(entry);
 											}
 										} else if (typeof reviewer.role === "string") {
-											const entry: Record<string, unknown> = {
-												reviewer_id: reviewer.role,
-												reviewer_type: "ROLE",
-											};
-											if (reviewer.mode !== undefined) entry.mode = reviewer.mode;
-											resolved.push(entry);
+											const roleId = yield* github.resolveRoleId(owner, reviewer.role).pipe(
+												Effect.catchTag("GitHubApiError", (err) =>
+													Effect.gen(function* () {
+														yield* logger.syncError(`resolve role '${reviewer.role}'`, err.message);
+														return undefined;
+													}),
+												),
+											);
+											if (roleId !== undefined) {
+												const entry: Record<string, unknown> = {
+													reviewer_id: roleId,
+													reviewer_type: "ROLE",
+												};
+												if (reviewer.mode !== undefined) entry.mode = reviewer.mode;
+												resolved.push(entry);
+											}
 										}
 									}
 									saaOut.delegated_bypass_reviewers = resolved;

--- a/package/src/services/SyncEngine.ts
+++ b/package/src/services/SyncEngine.ts
@@ -430,6 +430,11 @@ export const SyncEngineLive = Layer.effect(
 							codeScanningRefs.map((ref) => config.code_scanning[ref]),
 						);
 						const hasSecurity = Object.keys(mergedSecurity).length > 0;
+						// SecurityGroupSchema rejects this contradiction in a single group, but
+						// last-write-wins merging across multiple referenced groups can recreate
+						// it. Detect and skip the sync rather than letting GitHub return 422.
+						const securityContradiction =
+							mergedSecurity.automated_security_fixes === true && mergedSecurity.vulnerability_alerts === false;
 						const hasCodeScanning = Object.keys(mergedCodeScanning).length > 0;
 						const hasSecrets = secretScopes.some((s) => (resolvedSecrets.get(s)?.size ?? 0) > 0);
 						const hasVariables = resolvedVariables.size > 0;
@@ -495,7 +500,12 @@ export const SyncEngineLive = Layer.effect(
 								// Sync security features (vulnerability_alerts, automated_security_fixes,
 								// private_vulnerability_reporting). Diff against current state and only
 								// apply when the configured value differs.
-								if (hasSecurity) {
+								if (hasSecurity && securityContradiction) {
+									yield* logger.syncError(
+										"security merge",
+										"automated_security_fixes = true requires vulnerability_alerts to be enabled (or omitted); skipping security sync",
+									);
+								} else if (hasSecurity) {
 									if (mergedSecurity.vulnerability_alerts !== undefined) {
 										const desired = mergedSecurity.vulnerability_alerts;
 										const current = yield* github.getVulnerabilityAlerts(owner, repoName).pipe(

--- a/package/src/services/SyncLogger.ts
+++ b/package/src/services/SyncLogger.ts
@@ -12,7 +12,7 @@ export interface SyncLoggerService {
 	readonly repoStart: (owner: string, repo: string) => Effect.Effect<void>;
 	readonly repoSkip: (owner: string, repo: string, reason: string) => Effect.Effect<void>;
 	readonly syncSummary: (
-		resource: "secret" | "variable" | "ruleset" | "environment",
+		resource: "secret" | "variable" | "ruleset" | "environment" | "security feature" | "code scanning",
 		count: number,
 		detail: string,
 	) => Effect.Effect<void>;
@@ -34,6 +34,8 @@ export class SyncLogger extends Context.Tag("SyncLogger")<SyncLogger, SyncLogger
 function pluralize(resource: string, count: number): string {
 	if (count === 1) return resource;
 	if (resource === "ruleset") return "rulesets";
+	if (resource === "security feature") return "security features";
+	if (resource === "code scanning") return "code scanning";
 	return `${resource}s`;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,12 +6,21 @@ settings:
 
 catalogs:
   silk:
+    '@effect/cli':
+      specifier: ^0.75.1
+      version: 0.75.1
+    '@effect/platform':
+      specifier: ^0.96.1
+      version: 0.96.1
+    '@effect/platform-node':
+      specifier: ^0.106.0
+      version: 0.106.0
     '@types/node':
       specifier: ^25.6.0
       version: 25.6.0
     '@typescript/native-preview':
-      specifier: ^7.0.0-dev.20260422.1
-      version: 7.0.0-dev.20260423.1
+      specifier: ^7.0.0-dev.20260424.2
+      version: 7.0.0-dev.20260427.1
     tsx:
       specifier: ^4.21.0
       version: 4.21.0
@@ -27,7 +36,7 @@ overrides:
   smol-toml: '>=1.6.1'
   tmp: ^0.2.4
 
-pnpmfileChecksum: sha256-c9H7NdFuy+EHPxtzs2AyECsNH3ZP4b8bcqm4aWTxXV0=
+pnpmfileChecksum: sha256-tsqtD83NHdXTwsFr2aSdMx4G3nbzFEP7M/MNbxJuYRg=
 
 importers:
 
@@ -41,13 +50,13 @@ importers:
         version: 0.6.0(@commitlint/cli@20.5.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3))(@commitlint/config-conventional@20.5.0)(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/typeclass@0.40.0(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(commitizen@4.3.1(@types/node@25.6.0)(typescript@6.0.3))(husky@9.1.7)
       '@savvy-web/lint-staged':
         specifier: ^1.0.0
-        version: 1.0.0(0f12be85d1e96e8b2b8418ff2a3a5a97)
+        version: 1.0.0(2e36ec0fdc856673f7dc1eac3a7968df)
       '@savvy-web/rslib-builder':
         specifier: ^0.20.2
-        version: 0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(jiti@2.6.1)(typescript@6.0.3)
+        version: 0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260427.1)(jiti@2.6.1)(typescript@6.0.3)
       '@savvy-web/vitest':
         specifier: ^1.3.1
-        version: 1.3.1(836e59bcfd457e9b6b9b172db53235d4)
+        version: 1.3.1(e1d3ea0285cbdf1adcb685397331276c)
       reposets:
         specifier: workspace:*
         version: link:package/dist/npm
@@ -61,13 +70,13 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0
       '@effect/cli':
-        specifier: ^0.75.1
+        specifier: catalog:silk
         version: 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform':
-        specifier: ^0.96.0
+        specifier: catalog:silk
         version: 0.96.1(effect@3.21.2)
       '@effect/platform-node':
-        specifier: ^0.106.0
+        specifier: catalog:silk
         version: 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@octokit/rest':
         specifier: ^22.0.1
@@ -86,20 +95,20 @@ importers:
         version: 1.0.3
       xdg-effect:
         specifier: ^1.0.0
-        version: 1.0.0(0d43dc997f5621fc2ca1b6215331264a)
+        version: 1.0.0(df1c6b21a4da8e677dd9bca2b216bee7)
     devDependencies:
       '@savvy-web/rslib-builder':
         specifier: ^0.20.2
-        version: 0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(jiti@2.6.1)(typescript@6.0.3)
+        version: 0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260427.1)(jiti@2.6.1)(typescript@6.0.3)
       '@types/node':
         specifier: catalog:silk
         version: 25.6.0
       '@typescript/native-preview':
         specifier: catalog:silk
-        version: 7.0.0-dev.20260423.1
+        version: 7.0.0-dev.20260427.1
       ajv:
-        specifier: ^8.18.0
-        version: 8.18.0
+        specifier: ^8.20.0
+        version: 8.20.0
       tsx:
         specifier: catalog:silk
         version: 4.21.0
@@ -294,8 +303,8 @@ packages:
     resolution: {integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==}
     engines: {node: '>=v18'}
 
-  '@commitlint/load@20.5.0':
-    resolution: {integrity: sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==}
+  '@commitlint/load@20.5.2':
+    resolution: {integrity: sha512-zmr0RGDz7vThxW1I8ohb9yBjnGuH9mqwJpn21hInjGla+IlLOkS9ey0+dD5HlkzFlY0lX2NYdA2lDW6/0rO7Gw==}
     engines: {node: '>=v18'}
 
   '@commitlint/message@20.4.3':
@@ -310,8 +319,8 @@ packages:
     resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
     engines: {node: '>=v18'}
 
-  '@commitlint/resolve-extends@20.5.0':
-    resolution: {integrity: sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==}
+  '@commitlint/resolve-extends@20.5.2':
+    resolution: {integrity: sha512-8EhSCU9eNos/5cI1yg64GW79UH1c64O69AfStCsj4zqy6An/qIphVEXj4/+2M6056T8coz00f+UXFn4WUUP1HQ==}
     engines: {node: '>=v18'}
 
   '@commitlint/rules@20.5.0':
@@ -1160,6 +1169,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.0.2':
+    resolution: {integrity: sha512-0Vo1W0ZekQ6jTIaSqiG/dgMrYXcKP/eUDNad87NhxfMfu/S5xZT8fk0AEMMk49IyvIIE56uw2Ua6rw8mnZtM+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rslib/core@0.21.3':
     resolution: {integrity: sha512-3kyF273GQWIky4rAGD+Nkewlc7OraRwM2rG6wMJ19cYeomN0OKokVbk0vvfLAcQu43mtEO+dnZk6BchUoRmQOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1529,50 +1548,50 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-wbLr6o5fROaCYt6cOpFhbe92FJAOdhAHwm/s8I/IyN5HbL1ULgel/wHaZiR+ws+27rgruNUiCENzTUg9vSz2bA==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-8zxaaEgIpHSadCoCAvUsp0C6WDH0dUXix7Mm7IBjh+EhSxI2clhXwPZTqgtDqbowXHeE82BG5mBbQx+CXDwGOQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-13MpNT+4MgkgrfiW2u03rnER5aB3yz9fA0bWEYh6IH3rIqA2AR3Dntp3QXW4sQrZf0SriXqHe2R7X3HCT5xmqA==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-6MjekGfajPtny/bBoBYJ+8dTOlgw6nhSSgJ3Us4R/4L8R90ll803Krz+iz907r1SnYeK5eWubDMV/p1ryLNXkQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-ICIkJDTqmn0R4Vs811+Ht2RYTk1OCrAhHCu0JthmhR216T1Tqgi5DWRoCprp3RL1qU6fLnxxrIpEbNlNN7XFYA==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-a1yG/vrLaN3dORvaMuNqXz5jcTaTEPBfhmq77vzqRn8As7EdqxtizPosfxB9K1s7PEB8NeGQKqHEQroPUCsPFg==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-CxUA15qbPQRvz2nanBpiv1h4tgXTCJJwqOtgKMSdIuPkow8dyYW3ba5oLoH/jZhS4792XislX659hlFrfiU6CQ==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-3bhv/NxU9FHIN3MSmoplIAkIHF62mlF9l5XooAFawwj8yscvPZih/m5fkYIiP5qGri3828XwGyT1Cksaft6FWQ==}
     engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-cWLFS4R8dOU1YuUJ/2VLeGMVIjgI3GGb/f9rRY5MbWHq5l3NNZh8y1QwAOrTh3+g3q6+znArfxVnD2hZHUz8Mw==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-lqaA9oF9ZSw1jn87+Ncxo0Sf0d65eVXMjAD0z44ne7QKFRgWd+QpvK4AXAG4lxnFR+XdndWlVm6O1/tdvcG7xQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-OWaGUI4+dHqYZv+k6sITx9Y27FNy3XzNFk4OrOiYtBkIO/xrb9TPMP4A5XI4n5zwRLIv3xne9g039xgRbaeyoQ==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-ZGXRDC0WPVK/Ky2fZRhy2EcNmdHg22biVYWcWgOUK5tCbJd/KJs3VXk758gn0UbFHEQAR5d7dsvDucCCjZkWpA==}
     engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-5MQjO/qdLwXpjW7Dy/1lNv7Vtpvo6bhCkbjan4PoRN5/eeyqEqDWxdf8AGE4btLmHqyIjEHRuYf7kp2tlAr6lQ==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-Ut4Hncq1IuSeNIfcPs1s719j8H3ZA+ogsJ53W3s/Wy1UF5BIhu5Hkspdc7TzGgJgYqGJKo/+pr4vsRnbBPdWgQ==}
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
-    resolution: {integrity: sha512-9WD7TJJlGvt9PQqJI/+44dVP4oqGQFIkYrpXt7nlQ0WgNIErN52x/XhxmJ4nWft06qejgPiUbPo4aYRNOmIHXg==}
+  '@typescript/native-preview@7.0.0-dev.20260427.1':
+    resolution: {integrity: sha512-g6L7hed1Y2OGwAzZ+vXoGSvtJUdWUtTqtsn/16+UjYbu3+6pol0cggdWj26SFxI41R+jLfnT2+JGtoXRBdH+RQ==}
     engines: {node: '>=16.20.0'}
     hasBin: true
 
@@ -1665,6 +1684,9 @@ packages:
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -2122,8 +2144,8 @@ packages:
   es-get-iterator@1.1.3:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2237,8 +2259,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.4.0:
-    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2451,9 +2473,9 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  global-directory@4.0.1:
-    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
-    engines: {node: '>=18'}
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   global-modules@1.0.0:
     resolution: {integrity: sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==}
@@ -2509,8 +2531,8 @@ packages:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -2584,13 +2606,13 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
-  ini@4.1.1:
-    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
-    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
   ini@4.1.3:
     resolution: {integrity: sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   inquirer@8.2.5:
     resolution: {integrity: sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==}
@@ -2777,8 +2799,8 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -3475,8 +3497,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -3819,8 +3841,8 @@ packages:
     resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
     engines: {node: '>=20'}
 
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
     engines: {node: '>=20'}
 
   string_decoder@1.3.0:
@@ -4526,7 +4548,7 @@ snapshots:
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.0
-      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@6.0.3)
+      '@commitlint/load': 20.5.2(@types/node@25.6.0)(typescript@6.0.3)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.1.1
@@ -4545,7 +4567,7 @@ snapshots:
   '@commitlint/config-validator@20.5.0':
     dependencies:
       '@commitlint/types': 20.5.0
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   '@commitlint/ensure@20.5.0':
     dependencies:
@@ -4575,11 +4597,11 @@ snapshots:
       '@commitlint/rules': 20.5.0
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.0(@types/node@25.6.0)(typescript@6.0.3)':
+  '@commitlint/load@20.5.2(@types/node@25.6.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
-      '@commitlint/resolve-extends': 20.5.0
+      '@commitlint/resolve-extends': 20.5.2
       '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.1(typescript@6.0.3))(typescript@6.0.3)
@@ -4609,11 +4631,11 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@20.5.0':
+  '@commitlint/resolve-extends@20.5.2':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/types': 20.5.0
-      global-directory: 4.0.1
+      global-directory: 5.0.0
       import-meta-resolve: 4.2.0
       lodash.mergewith: 4.6.2
       resolve-from: 5.0.0
@@ -4874,9 +4896,9 @@ snapshots:
 
   '@gwhitney/detect-indent@7.0.1': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.14)':
+  '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.15
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -4963,18 +4985,18 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.4.0(express@5.2.1)
-      hono: 4.12.14
-      jose: 6.2.2
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -5416,10 +5438,17 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)':
+  '@rsbuild/core@2.0.2':
     dependencies:
-      '@rsbuild/core': 2.0.0
-      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)
+      '@rspack/core': 2.0.0(@swc/helpers@0.5.21)
+      '@swc/helpers': 0.5.21
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
+  '@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3)':
+    dependencies:
+      '@rsbuild/core': 2.0.2
+      rsbuild-plugin-dts: 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.2)(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3)
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       typescript: 6.0.3
@@ -5576,14 +5605,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/lint-staged@1.0.0(0f12be85d1e96e8b2b8418ff2a3a5a97)':
+  '@savvy-web/lint-staged@1.0.0(2e36ec0fdc856673f7dc1eac3a7968df)':
     dependencies:
       '@effect/cli': 0.75.1(@effect/platform@0.96.1(effect@3.21.2))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/platform': 0.96.1(effect@3.21.2)
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@savvy-web/silk-effects': 0.3.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@types/node': 25.6.0
-      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      '@typescript/native-preview': 7.0.0-dev.20260427.1
       effect: 3.21.2
       husky: 9.1.7
       jsonc-effect: 0.2.1(effect@3.21.2)
@@ -5606,7 +5635,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/rslib-builder@0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(jiti@2.6.1)(typescript@6.0.3)':
+  '@savvy-web/rslib-builder@0.20.2(@pnpm/logger@1001.0.1)(@rslib/core@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3))(@types/node@25.6.0)(@typescript/native-preview@7.0.0-dev.20260427.1)(jiti@2.6.1)(typescript@6.0.3)':
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@microsoft/tsdoc': 0.16.0
@@ -5617,10 +5646,10 @@ snapshots:
       '@pnpm/lockfile.fs': 1100.0.3(@pnpm/logger@1001.0.1)
       '@pnpm/workspace.read-manifest': 1000.3.1
       '@rsbuild/core': 2.0.0
-      '@rslib/core': 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3)
+      '@rslib/core': 0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3)
       '@types/node': 25.6.0
       '@typescript-eslint/parser': 8.59.0(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
-      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      '@typescript/native-preview': 7.0.0-dev.20260427.1
       deep-equal: 2.2.3
       eslint: 10.2.1(jiti@2.6.1)
       eslint-plugin-tsdoc: 0.5.2(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
@@ -5655,10 +5684,10 @@ snapshots:
       workspaces-effect: 0.4.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       yaml-effect: 0.2.3(effect@3.21.2)
 
-  '@savvy-web/vitest@1.3.1(836e59bcfd457e9b6b9b172db53235d4)':
+  '@savvy-web/vitest@1.3.1(e1d3ea0285cbdf1adcb685397331276c)':
     dependencies:
       '@types/node': 25.6.0
-      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      '@typescript/native-preview': 7.0.0-dev.20260427.1
       '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
       typescript: 6.0.3
       vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -5856,36 +5885,36 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260423.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260427.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260423.1':
+  '@typescript/native-preview@7.0.0-dev.20260427.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260423.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260423.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260427.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260427.1
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
     dependencies:
@@ -5973,6 +6002,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5981,6 +6014,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -6166,7 +6206,7 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.0
+      string-width: 8.2.1
 
   cli-width@3.0.0: {}
 
@@ -6300,7 +6340,7 @@ snapshots:
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 20.5.0(@types/node@25.6.0)(typescript@6.0.3)
+      '@commitlint/load': 20.5.2(@types/node@25.6.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
@@ -6444,7 +6484,7 @@ snapshots:
       isarray: 2.0.5
       stop-iteration-iterator: 1.1.0
 
-  es-module-lexer@2.0.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -6604,7 +6644,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.4.0(express@5.2.1):
+  express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -6867,9 +6907,9 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  global-directory@4.0.1:
+  global-directory@5.0.0:
     dependencies:
-      ini: 4.1.1
+      ini: 6.0.0
 
   global-modules@1.0.0:
     dependencies:
@@ -6931,7 +6971,7 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
-  hono@4.12.14: {}
+  hono@4.12.15: {}
 
   html-escaper@2.0.2: {}
 
@@ -6987,9 +7027,9 @@ snapshots:
 
   ini@2.0.0: {}
 
-  ini@4.1.1: {}
-
   ini@4.1.3: {}
+
+  ini@6.0.0: {}
 
   inquirer@8.2.5:
     dependencies:
@@ -7164,7 +7204,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  jose@6.2.2: {}
+  jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
 
@@ -7183,13 +7223,13 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-effect@0.2.0(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(ajv@8.18.0)(effect@3.21.2):
+  json-schema-effect@0.2.0(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(ajv@8.20.0)(effect@3.21.2):
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
       effect: 3.21.2
     optionalDependencies:
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   json-schema-traverse@0.4.1: {}
 
@@ -8001,7 +8041,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.10:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8194,13 +8234,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.0)(@typescript/native-preview@7.0.0-dev.20260423.1)(typescript@6.0.3):
+  rsbuild-plugin-dts@0.21.3(@microsoft/api-extractor@7.58.7(@types/node@25.6.0))(@rsbuild/core@2.0.2)(@typescript/native-preview@7.0.0-dev.20260427.1)(typescript@6.0.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 2.0.0
+      '@rsbuild/core': 2.0.2
     optionalDependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
-      '@typescript/native-preview': 7.0.0-dev.20260423.1
+      '@typescript/native-preview': 7.0.0-dev.20260427.1
       typescript: 6.0.3
 
   run-async@2.4.1: {}
@@ -8407,7 +8447,7 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.0:
+  string-width@8.2.1:
     dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
@@ -8618,7 +8658,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.12
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -8665,7 +8705,7 @@ snapshots:
       '@vitest/snapshot': 4.1.5
       '@vitest/spy': 4.1.5
       '@vitest/utils': 4.1.5
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -8792,17 +8832,17 @@ snapshots:
 
   ws@8.20.0: {}
 
-  xdg-effect@1.0.0(0d43dc997f5621fc2ca1b6215331264a):
+  xdg-effect@1.0.0(df1c6b21a4da8e677dd9bca2b216bee7):
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.2)
       config-file-effect: 0.2.0(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       effect: 3.21.2
-      json-schema-effect: 0.2.0(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(ajv@8.18.0)(effect@3.21.2)
+      json-schema-effect: 0.2.0(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(ajv@8.20.0)(effect@3.21.2)
     optionalDependencies:
       '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/workflow@0.18.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(@effect/platform@0.96.1(effect@3.21.2))(effect@3.21.2))(effect@3.21.2)
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   y18n@5.0.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,5 +2,5 @@ packages:
   - package
 autoInstallPeers: true
 configDependencies:
-  "@savvy-web/pnpm-plugin-silk": 0.12.1+sha512-+eHl6vUz4G6BDjw7MDR2iDN4+DcximPGfyflbHR16UsayXKIo0JXwQvTSOcfsMw1p0SLEN9prsSq7df/ztO3Xw==
+  "@savvy-web/pnpm-plugin-silk": 0.13.0+sha512-R1+Q7p1yjmjQIZzSNpKm0r2oY35JtFSGGOw25u0oq16By6728YeMr6Oa7R2U1CjUVuvXQSKkshzvX8d8+RCZ/g==
 loglevel: info


### PR DESCRIPTION
## Summary

Adds three new GitHub API surfaces to the reposets sync pipeline:

* **Nested `security_and_analysis` block** under `[settings.<name>]` — folds into the existing `PATCH /repos` call. Covers secret scanning, push protection, AI detection, non-provider patterns, delegated alert dismissal/bypass, and Dependabot security updates. Delegated bypass reviewers accept team slugs (resolved to numeric `reviewer_id`s at sync time via a per-instance `org:slug` cache) or repository roles.
* **Top-level `[security.<name>]` groups** — toggle `vulnerability_alerts`, `automated_security_fixes`, `private_vulnerability_reporting` via the dedicated `PUT`/`DELETE` endpoints. Each is diffed against current state; only changed values are applied.
* **Top-level `[code_scanning.<name>]` groups** — configure CodeQL default setup (state, languages, query suite, threat model, runner). Languages are validated against GitHub's nine-value enum and filtered against detected repo languages.

License-aware: schema accepts every field; org-only fields are silently skipped on personal repos with a logged warning. GitHubClient grows from 22 to 30 methods; SyncEngine gains two new stages between settings and environments.

## Test plan

- [x] `pnpm vitest run` — 269 tests pass (216 unit + 52 int + 1 file new)
- [x] `pnpm run lint` (biome) — clean
- [x] `pnpm run lint:md` — clean
- [x] `pnpm exec savvy-changesets check .changeset` — passes
- [x] `pnpm run build` — clean (4 turbo tasks)
- [x] `pnpm --filter reposets exec tsgo --noEmit` — clean
- [x] Manual sync against personal repo with existing CodeQL — succeeds
- [x] Manual sync against personal repo without prior CodeQL — succeeds
- [ ] Test against an org-owned repo with GHAS license (covers delegated bypass reviewers + team slug resolution path)
- [ ] Test against an unlicensed private repo (expect 422 warnings without failing the run)

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>