### PR TITLE
docs: groom design docs and refresh user-facing documentation

### DIFF
--- a/.claude/design/refs.json
+++ b/.claude/design/refs.json
@@ -1,0 +1,35 @@
+{
+	"version": 1,
+	"refs": [
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/reposets/architecture.md",
+			"hash": "2ef59bdbe4aac0707213a2103d42162a89c4e4ecb3b08abc6a848b09ec11e519",
+			"recordedAt": "2026-06-12"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/reposets/cli.md",
+			"hash": "56d34befb358f2a8d81cc08c12b8884ee2c8ff30de9218feef709a3a6564be63",
+			"recordedAt": "2026-06-12"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/reposets/config-format.md",
+			"hash": "c3e64e7f59166e4639bcc271a7c9b07cbeab73b5155a7c2baa1362761656182d",
+			"recordedAt": "2026-06-12"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/reposets/json-schema.md",
+			"hash": "07f0b1e9acb49604c39ac6eea387227aa51f1cd9ab8879082b7ea7017c11fb78",
+			"recordedAt": "2026-06-12"
+		},
+		{
+			"source": "CLAUDE.md",
+			"target": ".claude/design/reposets/services.md",
+			"hash": "14bfcbcffee08e0936414314fda6bbb0200e756dd35773c294dcad91a688640c",
+			"recordedAt": "2026-06-12"
+		}
+	]
+}

--- a/.claude/design/reposets/architecture.md
+++ b/.claude/design/reposets/architecture.md
@@ -1,137 +1,68 @@
 ---
 module: reposets
 title: Architecture
+category: architecture
 status: current
-completeness: 95
-last-synced: 2026-04-27
+completeness: 90
+created: 2026-04-21
+updated: 2026-06-12
+last-synced: 2026-06-12
+related:
+  - services.md
+  - cli.md
+  - config-format.md
+  - json-schema.md
+dependencies: []
 ---
 
 ## Overview
 
-reposets is an Effect-based CLI for syncing GitHub repository settings,
-secrets, variables, rulesets, deployment environments, repository security
-features, and CodeQL default setup across personal and organization repos.
-Config files serve as distributable templates; environment-specific values
-are resolved from credential profiles at runtime.
+reposets is an Effect-based CLI for syncing GitHub repository settings, secrets, variables, rulesets, deployment environments, repository security features and CodeQL default setup across personal and organization repos. Config files are distributable templates; environment-specific values resolve from credential profiles at runtime. This doc owns the topology: which services exist, how layers compose and the order the sync pipeline runs in. Service interfaces live in `services.md`, the CLI surface in `cli.md` and the TOML schema in `config-format.md`.
 
-## Service Graph
+## Service graph
 
 ```text
-CLI Commands (--log-level flag, CliLogger)
+CLI commands (--log-level flag, CliLogger)
   |
   v
 ConfigFile services (xdg-effect ConfigFile.Tag)
-  |--- ReposetsConfigFile (schema + validate callback)
+  |--- ReposetsConfigFile (schema + validateConfigRefs callback)
   |--- ReposetsCredentialsFile (schema + XDG default path)
-  |--- makeConfigFilesLive(configFlag) factory
-  |      |--- ExplicitPath / StaticDir (--config flag)
-  |      |--- UpwardWalk (directory walk)
-  |      |--- XdgConfigResolver (XDG fallback)
+  |--- makeConfigFilesLive(configFlag) factory -> resolver chain
   |
   v
 SyncEngine (orchestration)
-  |--- CredentialResolver (resolve credential profile labels)
-  |      |--- OnePasswordClient (@1password/sdk)
-  |
-  |--- GitHubClient (Octokit wrapper + GraphQL mutations)
-  |      |--- crypto (NaCl sealed box encryption)
-  |
-  |--- SyncLogger (structured output by log level)
+  |--- CredentialResolver --- OnePasswordClient (@1password/sdk)
+  |--- GitHubClient (Octokit + GraphQL) --- crypto (NaCl sealed box)
+  |--- SyncLogger (tiered output)
 ```
 
-## Layer Composition
+## Layer composition
 
-Layers are composed at two levels:
+Layers compose at three levels:
 
-- **Root entrypoint** (`index.ts`): provides `NodeContext.layer` and
-  `CliLogger` (custom logger routing `Effect.log` to stdout and
-  `Effect.logError` to stderr)
-- **Per-command**: each command calls `makeConfigFilesLive(config)` to
-  provide `ReposetsConfigFile` and `ReposetsCredentialsFile` layers,
-  using the `--config` flag option to configure resolver chains
-- **Per-sync invocation**: `GitHubClientLive(token)` +
-  `OnePasswordClientLive` + `CredentialResolverLive` +
-  `SyncLoggerLive({ dryRun, logLevel })` + `SyncEngineLive` composed
-  in the sync command handler
+- Root entrypoint (`package/src/cli/index.ts`) provides `NodeContext.layer` and `CliLogger`, a custom logger that routes `Effect.log` to stdout and `Effect.logError` to stderr.
+- Per command: each command calls `makeConfigFilesLive(config)` to provide the `ReposetsConfigFile` and `ReposetsCredentialsFile` layers, using the `--config` flag to seed the resolver chain.
+- Per sync invocation: the sync handler composes `GitHubClientLive(token)`, `OnePasswordClientLive`, `CredentialResolverLive`, `SyncLoggerLive({ dryRun, logLevel })` and `SyncEngineLive`.
 
-## Data Flow
+The key constraint: layers are provided at the entrypoint and per-command handlers, never inside service implementations.
 
-1. CLI parses args via @effect/cli (global `--log-level` flag)
-2. Config path resolved via declarative resolver chain:
-   `ExplicitPath`/`StaticDir` (--config flag) > `UpwardWalk` (directory
-   walk) > `XdgConfigResolver` (XDG fallback)
-3. TOML files read from disk, parsed by smol-toml, validated by Effect
-   Schema; config cross-references validated by `validateConfigRefs`
-   callback
-4. SyncEngine iterates groups (`config.groups`), resolving credential
-   profiles per group
-5. CredentialResolver resolves all labels from the active profile's
-   `[resolve]` section (op/file/value sub-groups) into a `Map<string, string>`
-6. Secret and variable groups resolved by kind: `file` (read files),
-   `value` (use inline strings/objects), `resolved` (look up from
-   credential map)
-7. Rulesets collected from config as typed objects; shorthand fields
-   (`targets`, `pull_requests`, `status_checks`, boolean flags) normalized
-   via `normalizeRuleset()` into API-compatible format; `{ resolved }`
-   references substituted from the credential map with type coercion
-8. Owner type detected once per group via `GitHubClient.getOwnerType()`;
-   used downstream to strip org-only fields (e.g., `allow_forking` from
-   settings, and `secret_scanning_delegated_*` /
-   `delegated_bypass_reviewers` from `security_and_analysis`) on personal
-   accounts
-9. Settings stage: merged settings (REST `repos.update`) plus a folded
-   `security_and_analysis` block (transformed via
-   `transformSecurityAndAnalysis()`) plus GraphQL mutation for
-   `has_sponsorships` / `has_pull_requests`. Org-owned repos resolve
-   `delegated_bypass_reviewers` team slugs to numeric `reviewer_id`s via
-   `GitHubClient.resolveTeamId()` (cached per `org:slug`) before the PATCH
-10. Security features stage (between settings and secrets, implemented
-    inline in `SyncEngine.syncAll`): for each of `vulnerability_alerts`,
-    `automated_security_fixes`, and `private_vulnerability_reporting`,
-    probe current state via the corresponding `getXxx` method, compare to
-    the merged desired value, and PUT/DELETE only on diff
-11. Code scanning stage (after the security features stage, also inline):
-    filter configured CodeQL languages by what `listRepoLanguages` detects
-    (mapped through `REPO_LANG_TO_CODEQL`); warn (don't fail) on
-    non-detected entries; PATCH the default-setup endpoint (`202 Accepted`,
-    sent without polling for completion)
-12. Environments synced before secrets/variables (environments must exist
-    before scoped resources can be attached)
-13. GitHubClient applies remaining changes per repo: environments, secrets
-    by scope (actions/dependabot/codespaces/environments), variables by
-    scope (actions/environments), rulesets
-14. Cleanup phase deletes undeclared resources per scope, respecting
-    preserve lists and per-group cleanup configuration. (Security feature
-    toggles and code scanning default setup follow "leave alone if
-    omitted" semantics and have no `cleanup` scope of their own.)
-15. SyncLogger emits tiered output throughout (info summaries, verbose
-    per-operation, debug with source details)
+## Data flow
 
-## Error Model
+The sync pipeline is a delegation chain, not a flat function. The boundaries that matter:
 
-All errors are `Data.TaggedError` subclasses:
+1. The CLI resolves a config path through the declarative resolver chain (`--config` flag > upward walk > XDG fallback; see `config-format.md`), reads and parses the TOML, validates it against Effect Schema and runs the `validateConfigRefs` cross-reference check.
+2. `SyncEngine.syncAll` iterates config groups. Per group it resolves the owner, the credential profile and all credential labels (into a flat `Map<string, string>`), then detects the owner type once via `GitHubClient.getOwnerType()` to strip org-only fields on personal accounts.
+3. Per repo, the engine applies stages in a fixed order: settings (with folded `security_and_analysis` and resolved reviewer IDs) -> security features (diff-and-toggle) -> code scanning default setup -> environments -> secrets -> variables -> rulesets -> cleanup.
 
-- `ConfigError` - TOML parse or schema validation failure
-- `CredentialsError` - missing credentials file or profile
-- `ResolveError` - file not found, OP resolution failed, missing
-  credential label
-- `GitHubApiError` - API call failure (includes HTTP status); caught
-  per-operation so sync continues past individual failures
-- `SyncError` - orchestration-level failure
-- `OnePasswordError` - 1Password SDK failure
+Two ordering constraints are load-bearing and not obvious from the code: environments must sync before any environment-scoped secrets or variables, and cleanup runs last so freshly synced resources are never deleted. The security-features and code-scanning stages are implemented inline in `SyncEngine.syncAll` rather than as separate methods. See `services.md` for the per-stage detail and `package/src/services/SyncEngine.ts` for the full flow.
 
-## Testing Strategy
+Security feature toggles and code scanning default setup follow "leave alone if omitted" semantics — they have no `cleanup` scope of their own.
 
-Each service has Live and Test layer implementations:
+## Error model
 
-- `GitHubClientTest()` - records API calls, returns empty lists (covers
-  all 30 service methods including environment, security feature, code
-  scanning, and team-resolver operations)
-- `OnePasswordClientTest(stubs)` - returns deterministic values
-- `makeConfigFilesLive` - used directly in tests (builds xdg-effect
-  resolver chains for config + credentials)
-- `CredentialResolverLive` - tested with real filesystem + mock OP client
-- `SyncLoggerLive` - tested with Ref-based output capture
+All errors are `Data.TaggedError` subclasses; see the union in `package/src/errors.ts`. The load-bearing decision: `GitHubApiError` is caught per operation so a single failed API call does not abort the rest of the sync.
 
-230 tests (unit + integration) cover schemas, services, CLI commands,
-and utilities.
+## Rationale
+
+Config-as-template plus runtime credential resolution lets the same `reposets.config.toml` be committed and shared while secrets stay out of version control in `reposets.credentials.toml`. Modeling the pipeline as Effect programs gives uniform error handling and lets every service ship a Live and a Test layer, so the orchestration can be exercised without touching the GitHub API.

--- a/.claude/design/reposets/cli.md
+++ b/.claude/design/reposets/cli.md
@@ -1,31 +1,32 @@
 ---
 module: reposets
 title: CLI Commands
+category: architecture
 status: current
-completeness: 95
-last-synced: 2026-04-23
+completeness: 90
+created: 2026-04-21
+updated: 2026-06-12
+last-synced: 2026-06-12
+related:
+  - architecture.md
+  - services.md
+  - config-format.md
+dependencies: []
 ---
 
-## Entry Point
+## Overview
 
-`package/src/cli/index.ts` bootstraps the CLI:
+The CLI is built with `@effect/cli`. Each subcommand is one file under `package/src/cli/commands/`; the root command and runtime bootstrap live in `package/src/cli/index.ts`. This doc covers the command surface and what each command does at the topology level — see the command source for argument and flag detail.
 
-1. Root command created with `Command.make("reposets")`
-2. All subcommands registered via `Command.withSubcommands`
-3. `Command.run` creates the CLI handler
-4. `Effect.suspend(() => cli(process.argv))` defers evaluation
-5. `NodeContext.layer` and `CliLogger` provided at root (CliLogger
-   replaces the default Effect logger, routing `Effect.log` to stdout
-   and `Effect.logError` to stderr via `globalThis.console`)
-6. Each command provides its own `makeConfigFilesLive(config)` layer
-7. `NodeRuntime.runMain` executes the program
+## Entry point
 
-## Global Options
+`package/src/cli/index.ts` registers subcommands via `Command.withSubcommands`, defers evaluation with `Effect.suspend(() => cli(process.argv))` and provides `NodeContext.layer` plus `CliLogger` at the root before `NodeRuntime.runMain`. `CliLogger` replaces the default Effect logger so `Effect.log` reaches stdout and `Effect.logError` reaches stderr. Each command supplies its own `makeConfigFilesLive(config)` layer.
 
-`--log-level silent|info|verbose|debug` (default: `info`) - sets output
-verbosity. Overrides `log_level` in config.
+## Global options
 
-## Command Tree
+`--log-level silent|info|verbose|debug` (default `info`) sets output verbosity and overrides `log_level` in config.
+
+## Command tree
 
 ```text
 reposets [--log-level]
@@ -40,61 +41,11 @@ reposets [--log-level]
     delete --profile
 ```
 
-## sync
+## Commands
 
-Loads config and credentials, builds service layers per credential
-profile, delegates to SyncEngine. Log level resolved from config
-`log_level` field, overridden by `--log-level` CLI flag.
-SyncLoggerLive wired with `{ dryRun, logLevel }`. Supports filtering
-by group or repo and dry-run mode.
-
-Layer composition: `GitHubClientLive(token)` + `OnePasswordClientLive` +
-`CredentialResolverLive` + `SyncLoggerLive` -> `SyncEngineLive`, all
-provided to the `SyncEngine.syncAll()` call.
-
-## list
-
-Displays a config summary: repo groups with their referenced settings,
-environments, secrets (by scope including environment-scoped), variables
-(by scope including environment-scoped), rulesets, owner, and credential
-profile.
-
-## validate
-
-Schema compliance + reference integrity checks without hitting the
-GitHub API:
-
-- Config and credentials schema validation (via `configFile.discover`
-  which runs `validateConfigRefs` automatically)
-- Cross-reference validation (settings, secrets, variables, rulesets,
-  environments group references) performed by `validateConfigRefs`
-  callback during config loading
-- File path existence checks (file-kind secret/variable groups)
-- Credential profile reference checks
-
-## doctor
-
-Everything validate does, plus Levenshtein-based typo detection for
-unknown keys in the config. Reports suggestions like "unknown key
-'has_wikis' -- did you mean 'has_wiki'?"
-
-Checks top-level keys, repo group keys, and per-group cleanup keys
-(including nested `cleanup.secrets` and `cleanup.variables` sub-keys)
-against known sets.
-
-## init
-
-Scaffolds `reposets.config.toml` and `reposets.credentials.toml`:
-
-- Default (no flags): creates in XDG config dir, adds `.gitignore`
-  containing `reposets.credentials.toml` to the config dir
-- `--project`: creates in cwd, appends `reposets.credentials.toml` to
-  the project's `.gitignore`
-
-## credentials
-
-Manages named credential profiles in `reposets.credentials.toml`:
-
-- `create` - add a profile with `--github-token` and/or `--op-token`
-- `list` - show profiles with tokens redacted (first/last 4 chars)
-- `delete` - remove a profile by name
+- `sync` — loads config and credentials, builds the per-profile service layers and delegates to `SyncEngine.syncAll()`. Supports filtering by group or repo and dry-run mode. Layer composition for this command is described in `architecture.md`.
+- `list` — prints a config summary: each group with its referenced settings, environments, secrets and variables (by scope, including environment-scoped), rulesets, owner and credential profile.
+- `validate` — schema and reference-integrity checks without hitting the GitHub API. Cross-reference validation runs through `validateConfigRefs` during config loading; the command additionally checks file-kind group paths and credential-profile references.
+- `doctor` — everything `validate` does, plus Levenshtein typo detection for unknown keys (top-level, group and per-group cleanup keys, including nested `cleanup.secrets`/`cleanup.variables`).
+- `init` — scaffolds `reposets.config.toml` and `reposets.credentials.toml`. Default writes to the XDG config dir and gitignores the credentials file there; `--project` writes to cwd and appends the credentials file to the project `.gitignore`.
+- `credentials create|list|delete` — manages named profiles in `reposets.credentials.toml`; `list` redacts tokens to first/last four characters.

--- a/.claude/design/reposets/config-format.md
+++ b/.claude/design/reposets/config-format.md
@@ -1,38 +1,39 @@
 ---
 module: reposets
 title: Configuration Format
+category: other
 status: current
-completeness: 95
-last-synced: 2026-04-27
+completeness: 90
+created: 2026-04-21
+updated: 2026-06-12
+last-synced: 2026-06-12
+related:
+  - architecture.md
+  - services.md
+  - json-schema.md
+dependencies: []
 ---
 
-## Files
+## Overview
+
+reposets reads two TOML files. This doc describes their structure and the schemas that validate them — the authoritative shapes live in `package/src/schemas/`. Generation of editor JSON schemas from these definitions is a separate build-time subsystem; see `json-schema.md`.
 
 | File | Purpose | Location |
 | :--- | :------ | :------- |
 | `reposets.config.toml` | Groups, settings, environments, secrets, variables, rulesets, security, code_scanning, cleanup | XDG or project-local |
 | `reposets.credentials.toml` | Named credential profiles with resolve sections (gitignored) | XDG config dir |
 
-## Config Path Resolution
+## Config path resolution
 
-Resolution uses a declarative resolver chain (`FirstMatch` strategy,
-first match wins). `makeConfigFilesLive(configFlag)` builds the chain:
+A declarative resolver chain (first match wins) finds the config. `makeConfigFilesLive(configFlag)` builds it:
 
-1. `--config` flag: `ExplicitPath(flag)` if file, `StaticDir({ dir,
-   filename })` if directory (prepended when `--config` is provided)
-2. `UpwardWalk({ filename })` - walk up from cwd looking for
-   `reposets.config.toml`
-3. `XdgConfigResolver({ filename })` - `$XDG_CONFIG_HOME/reposets/` or
-   `~/.config/reposets/`
+1. `--config` flag: `ExplicitPath(flag)` for a file or `StaticDir` for a directory, prepended when the flag is present.
+2. `UpwardWalk` — walk up from cwd looking for `reposets.config.toml`.
+3. `XdgConfigResolver` — `$XDG_CONFIG_HOME/reposets/` or `~/.config/reposets/`.
 
-Credentials use a separate chain: `UpwardWalk` + `XdgConfigResolver`
-only (no `--config` flag support), with `XdgSavePath` as the default
-save location.
+Credentials use a separate chain — `UpwardWalk` + `XdgConfigResolver` only, no `--config` support — with `XdgSavePath` as the default save location. File references in `file`-kind groups resolve relative to the directory containing `reposets.config.toml`.
 
-File references in `file`-kind groups resolve relative to the directory
-containing `reposets.config.toml`.
-
-## Config Structure
+## Config structure
 
 ```toml
 owner = "spencerbeggs"
@@ -40,7 +41,6 @@ log_level = "info"
 
 [settings.default]
 has_wiki = false
-has_discussions = false
 delete_branch_on_merge = true
 
 [settings.default.security_and_analysis]
@@ -58,9 +58,6 @@ state = "configured"
 languages = ["javascript-typescript", "python"]
 query_suite = "extended"
 
-[environments.staging]
-wait_timer = 0
-
 [environments.production]
 wait_timer = 30
 prevent_self_review = true
@@ -68,9 +65,6 @@ prevent_self_review = true
 [[environments.production.reviewers]]
 type = "User"
 id = 12345
-
-[environments.production.deployment_branches]
-# "all", "protected", or array of custom policies
 
 [secrets.deploy.file]
 NPM_TOKEN = "./private/NPM_TOKEN"
@@ -80,10 +74,6 @@ API_KEY = "SILK_API_KEY"
 
 [variables.turbo.value]
 NODE_ENV = "production"
-DO_NOT_TRACK = "1"
-
-[variables.bot.resolved]
-BOT_NAME = "SILK_BOT_NAME"
 
 [rulesets.branch-protection]
 name = "branch-protection"
@@ -94,10 +84,8 @@ non_fast_forward = true
 
 [rulesets.branch-protection.pull_requests]
 approvals = 1
-dismiss_stale_reviews = false
 
 [rulesets.branch-protection.status_checks]
-update_branch = true
 default_integration_id = { resolved = "SILK_APP_ID" }
 
 [[rulesets.branch-protection.status_checks.required]]
@@ -106,9 +94,9 @@ context = "CI"
 [groups.my-projects]
 repos = ["repo-one", "repo-two"]
 settings = ["default"]
-environments = ["staging", "production"]
+environments = ["production"]
 secrets = { actions = ["deploy", "api"], dependabot = ["deploy"], environments = { production = ["api"] } }
-variables = { actions = ["turbo", "bot"], environments = { staging = ["turbo"] } }
+variables = { actions = ["turbo"], environments = { staging = ["turbo"] } }
 rulesets = ["branch-protection"]
 security = ["baseline"]
 code_scanning = ["baseline"]
@@ -120,178 +108,70 @@ environments = true
 [groups.my-projects.cleanup.secrets]
 actions = true
 dependabot = { preserve = ["LEGACY_TOKEN"] }
-environments = true
 
 [groups.my-projects.cleanup.variables]
 actions = true
-environments = true
 ```
 
-## Resource Group Model
+## Resource group model
 
-Secret and variable groups are discriminated by kind. Each group is
-exactly one kind, determined by its sub-key:
+Secret and variable groups are discriminated by kind — each group is exactly one kind, determined by its sub-key:
 
-- `{ file = { NAME = "path" } }` - read from disk relative to config dir
-- `{ value = { NAME = "string" } }` - inline; strings as-is, TOML tables
-  JSON-stringified
-- `{ resolved = { NAME = "LABEL" } }` - map names to credential labels
-  from the active profile's `[resolve]` section
+- `{ file = { NAME = "path" } }` — read from disk relative to the config dir.
+- `{ value = { NAME = "string" } }` — inline; strings as-is, TOML tables JSON-stringified.
+- `{ resolved = { NAME = "LABEL" } }` — map names to credential labels from the active profile's `[resolve]` section.
 
-Rulesets are defined inline as typed TOML tables (see Ruleset Schema).
-Integer fields in rulesets accept `{ resolved = "LABEL" }` for runtime
-substitution.
+Rulesets are typed TOML tables (see Ruleset schema). Integer fields in rulesets accept `{ resolved = "LABEL" }` for runtime substitution.
 
-## Ruleset Schema
+## Ruleset schema
 
-Rulesets are a discriminated union by `type` field: `BranchRuleset` or
-`TagRuleset`. Branch rulesets support all 21 rule types plus the
-`pull_requests` shorthand; tag rulesets support 16 rule types (no
-`merge_queue`, `pull_request`, `branch_name_pattern`, `workflows`,
-`code_scanning`, `copilot_code_review`).
+Rulesets are a discriminated union by `type`: `BranchRuleset` or `TagRuleset`. Branch rulesets support the full GitHub rule set plus the `pull_requests` shorthand; tag rulesets support the subset that applies to tags (no `merge_queue`, `pull_request`, `branch_name_pattern`, `workflows`, `code_scanning` or `copilot_code_review`). The authoritative rule list and per-type support are in `package/src/schemas/ruleset.ts`.
 
-The full 22 GitHub rule types supported across both:
-`creation`, `update`, `deletion`, `required_linear_history`,
-`required_signatures`, `non_fast_forward`, `pull_request`,
-`required_status_checks`, `required_deployments`, `merge_queue`,
-`commit_message_pattern`, `commit_author_email_pattern`,
-`committer_email_pattern`, `branch_name_pattern`, `tag_name_pattern`,
-`file_path_restriction`, `file_extension_restriction`,
-`max_file_path_length`, `max_file_size`, `workflows`, `code_scanning`,
-`copilot_code_review`.
+### Shorthand fields
 
-### Shorthand Fields
+`normalizeRuleset()` converts ergonomic shorthand fields into the API-compatible rule format, then strips them from the output:
 
-Rulesets support several shorthand fields that `normalizeRuleset()`
-converts into API-compatible format:
+- `targets` (`"default"` | `"all"` | array of `{ include }` / `{ exclude }` patterns) -> `conditions.ref_name`.
+- `pull_requests` (branch only) -> the `pull_request` rule.
+- `status_checks` -> the `required_status_checks` rule; a top-level `default_integration_id` is applied to checks that omit it.
+- Boolean flags (`creation`, `update`, `deletion`, `required_linear_history`, `required_signatures`, `non_fast_forward`) -> the corresponding parameterless rules.
+- `deployments` (array of environment names) -> the `required_deployments` rule.
 
-- `targets` - `"default"` | `"all"` | array of `{ include }` /
-  `{ exclude }` patterns -> `conditions.ref_name`
-- `pull_requests` (branch only) - `{ approvals, dismiss_stale_reviews,
-  code_owner_review, last_push_approval, resolve_threads, merge_methods,
-  reviewers }` -> `pull_request` rule
-- `status_checks` - `{ update_branch, on_creation,
-  default_integration_id, required }` -> `required_status_checks` rule;
-  `default_integration_id` applied to checks that omit it
-- Boolean flags: `creation`, `update`, `deletion`,
-  `required_linear_history`, `required_signatures`, `non_fast_forward` ->
-  corresponding parameterless rules
-- `deployments` - array of environment names ->
-  `required_deployments` rule
+Fields `actor_id`, `integration_id` and `repository_id` accept a static integer or `{ resolved = "LABEL" }`.
 
-All shorthand fields are stripped from the output after normalization.
+## Environment schema
 
-Fields `actor_id`, `integration_id`, and `repository_id` accept either
-a static integer or `{ resolved = "LABEL" }`.
+Top-level `[environments.<name>]` tables define deployment environments:
 
-## Environment Schema
+- `wait_timer` — minutes to wait before deployments (0-43200).
+- `prevent_self_review` — prevent the deployment trigger from approving.
+- `reviewers` — array of `{ type: "User" | "Team", id: number }`.
+- `deployment_branches` — `"all"` | `"protected"` | array of `{ name, type? }` custom policies (type defaults to `"branch"`).
 
-Top-level `[environments.<name>]` tables define deployment environment
-configurations:
+Environments referenced by a group's `environments` array sync via `GitHubClient.syncEnvironment()` before secrets and variables.
 
-- `wait_timer` - minutes to wait before allowing deployments (0-43200)
-- `prevent_self_review` - prevent deployment trigger from approving
-- `reviewers` - array of `{ type: "User"|"Team", id: number }`
-- `deployment_branches` - `"all"` | `"protected"` | array of
-  `{ name, type? }` custom policies (type defaults to `"branch"`)
+## Secret and variable scopes
 
-Environments referenced by `group.environments` array are synced via
-`GitHubClient.syncEnvironment()` before secrets/variables.
+Secrets are assigned through a `SecretScopes` struct: `actions`, `dependabot` and `codespaces` (each an array of secret group names) plus `environments` (a record mapping environment names to arrays of secret group names). Variables use a `VariableScopes` struct with `actions` and `environments`. The same group can be assigned to different scopes on different groups.
 
-## Secret Scopes
+## Group reference fields
 
-Scoping is now structured as a `SecretScopes` object with four fields:
+`[groups.<name>]` accepts reference arrays, each pointing into the matching top-level table: `settings`, `rulesets`, `environments`, `security` and `code_scanning`, plus the `secrets` and `variables` scope structs above. The `validateConfigRefs` callback (the `ReposetsConfigFile` validator) collects unknown references across every array and reports them in a single `ConfigError`.
 
-- `actions` - array of secret group names for GitHub Actions secrets
-- `dependabot` - array of secret group names for Dependabot secrets
-- `codespaces` - array of secret group names for Codespaces secrets
-- `environments` - record mapping environment names to arrays of secret
-  group names for environment-scoped secrets
+## Settings schema
 
-The same secret group can be assigned to different scopes on different
-groups.
+`SettingsGroupSchema` is a typed struct of known fields with an index signature for pass-through of unknown fields. See `package/src/schemas/config.ts` for the field list. Known fields cover repository features, forking, merge strategies and commit formatting, branch-delete-on-merge and `web_commit_signoff_required`. `has_sponsorships` and `has_pull_requests` are synced via the GraphQL `updateRepository` mutation rather than REST.
 
-## Variable Scopes
+### `security_and_analysis` block
 
-Variables use a `VariableScopes` object with two fields:
+`SettingsGroupSchema` allows a nested `security_and_analysis` table whose fields ride along with the same `PATCH /repos/{owner}/{repo}` call as the rest of the settings (reshaped by `transformSecurityAndAnalysis()` in `GitHubClient`). Status fields take `"enabled" | "disabled"` and cover the GHAS toggles, secret-scanning variants and `dependabot_security_updates`; some are GHAS-licensed and some are org-only. The exact field set is `SAA_STATUS_FIELDS` in `package/src/services/GitHubClient.ts`.
 
-- `actions` - array of variable group names for GitHub Actions variables
-- `environments` - record mapping environment names to arrays of variable
-  group names for environment-scoped variables
-
-## Group Reference Fields
-
-`[groups.<name>]` accepts the following reference arrays, each pointing
-into the matching top-level table:
-
-- `settings: string[]` -> `[settings.*]`
-- `rulesets: string[]` -> `[rulesets.*]`
-- `environments: string[]` -> `[environments.*]`
-- `security: string[]` -> `[security.*]` (new)
-- `code_scanning: string[]` -> `[code_scanning.*]` (new)
-
-Plus the `secrets: SecretScopes` and `variables: VariableScopes` structs
-described above.
-
-The `validateConfigRefs` callback (registered as the
-`ReposetsConfigFile` validator) collects errors across every reference
-array, including the new `security` and `code_scanning` arrays, and
-reports all unknown references in a single `ConfigError`.
-
-## Settings Schema
-
-The `SettingsGroupSchema` is a typed struct with 20+ known fields and
-pass-through for additional unknown fields via index signature. Known
-fields include:
-
-- Repository features: `is_template`, `has_wiki`, `has_issues`,
-  `has_projects`, `has_discussions`, `has_sponsorships` (GraphQL),
-  `has_pull_requests` (GraphQL)
-- Forking: `allow_forking`
-- Merge strategies: `allow_merge_commit`, `allow_squash_merge`,
-  `allow_rebase_merge`, `allow_auto_merge`, `allow_update_branch`
-- Merge commit formatting: `squash_merge_commit_title`,
-  `squash_merge_commit_message`, `merge_commit_title`,
-  `merge_commit_message`
-- Cleanup: `delete_branch_on_merge`
-- Security: `web_commit_signoff_required`
-
-Fields `has_sponsorships` and `has_pull_requests` are synced via GraphQL
-`updateRepository` mutation (not available in REST API).
-
-### `security_and_analysis` Block
-
-`SettingsGroupSchema` allows a nested `security_and_analysis` table whose
-fields ride along with the same `PATCH /repos/{owner}/{repo}` call as the
-rest of the settings block (see `transformSecurityAndAnalysis()` in
-`GitHubClient`). Status fields take `"enabled" | "disabled"`:
-
-- `advanced_security` (GHAS-licensed) - master GHAS toggle
-- `code_security` (GHAS-licensed)
-- `secret_scanning`
-- `secret_scanning_push_protection`
-- `secret_scanning_ai_detection` (GHAS-licensed)
-- `secret_scanning_non_provider_patterns` (GHAS-licensed)
-- `secret_scanning_delegated_alert_dismissal` (org-only)
-- `secret_scanning_delegated_bypass` (org-only)
-- `dependabot_security_updates`
-
-Plus an optional `delegated_bypass_reviewers` array (org-only). Each
-entry is a discriminated union: exactly one of `team` (a GitHub team
-slug) or `role` (an organization role name from
-`GET /orgs/{org}/organization-roles` such as `all_repo_admin` or a
-custom role like `security_manager`), with an optional
-`mode = "ALWAYS" | "EXEMPT"`. Both forms are resolved to numeric
-`reviewer_id`s at sync time -- team slugs via
-`GitHubClient.resolveTeamId()` and role names via
-`GitHubClient.resolveRoleId()`. Role IDs are per-org even for predefined
-roles, so the resolver must consult the live API per (org, role) pair.
+The block also accepts an org-only `delegated_bypass_reviewers` array. Each entry is a discriminated union of exactly one of `team` (a GitHub team slug) or `role` (an organization role name from `GET /orgs/{org}/organization-roles`), with an optional `mode = "ALWAYS" | "EXEMPT"`. Both forms resolve to numeric `reviewer_id`s at sync time — team slugs via `GitHubClient.resolveTeamId()`, role names via `GitHubClient.resolveRoleId()`. Role IDs are per-org even for predefined roles, so resolution consults the live API per (org, role) pair.
 
 ```toml
 [settings.oss-defaults.security_and_analysis]
 secret_scanning = "enabled"
 secret_scanning_push_protection = "enabled"
-secret_scanning_ai_detection = "enabled"
 dependabot_security_updates = "enabled"
 
 [[settings.oss-defaults.security_and_analysis.delegated_bypass_reviewers]]
@@ -303,106 +183,31 @@ role = "admin"
 mode = "EXEMPT"
 ```
 
-GHAS-licensed fields generally succeed on public repos and fail
-(HTTP 422) on unlicensed private repos; org-only fields are silently
-stripped from the merged block on personal accounts before the PATCH.
-Omitting any field means "leave alone" - no separate cleanup scope.
+GHAS-licensed fields generally succeed on public repos and fail (HTTP 422) on unlicensed private repos; org-only fields are stripped from the merged block on personal accounts before the PATCH. Omitting any field means "leave alone" — there is no cleanup scope for it.
 
-## Security Group Schema
+## Security group schema
 
-Top-level `[security.<name>]` groups configure repository security
-features that have dedicated PUT/DELETE endpoints. Each field is an
-optional boolean; omitted fields are "leave alone".
+Top-level `[security.<name>]` groups configure the repository security features that have dedicated PUT/DELETE endpoints. Each field is an optional boolean; omitted fields are "leave alone".
 
-- `vulnerability_alerts` - Dependabot vulnerability alerts
-  (`PUT`/`DELETE /repos/{o}/{r}/vulnerability-alerts`)
-- `automated_security_fixes` - Dependabot security PRs
-  (`PUT`/`DELETE /repos/{o}/{r}/automated-security-fixes`); requires
-  `vulnerability_alerts` to also be enabled
-- `private_vulnerability_reporting` - private vulnerability reporting
-  inbox (`PUT`/`DELETE /repos/{o}/{r}/private-vulnerability-reporting`)
+- `vulnerability_alerts` — Dependabot vulnerability alerts.
+- `automated_security_fixes` — Dependabot security PRs; requires `vulnerability_alerts` to also be enabled.
+- `private_vulnerability_reporting` — private vulnerability reporting inbox.
 
-```toml
-[security.baseline]
-vulnerability_alerts = true
-automated_security_fixes = true
-private_vulnerability_reporting = true
-```
+Groups reference these via the `security: string[]` field. Multiple references merge last-write-wins via `mergeSecurityGroups()`; the SyncEngine probes current state with the matching `getXxx` method and only toggles on diff.
 
-Groups reference security groups via the `security: string[]` field on
-`[groups.<name>]`. Multiple references are merged last-write-wins by
-`mergeSecurityGroups()` at sync time; the SyncEngine probes current
-state via the matching `getXxx` GitHubClient method and only PUTs/DELETEs
-on diff.
+## Code scanning group schema
 
-## Code Scanning Group Schema
+Top-level `[code_scanning.<name>]` groups configure CodeQL default setup, applied via `PATCH /repos/{o}/{r}/code-scanning/default-setup`. Fields: `state` (`"configured" | "not-configured"`), `languages` (default-setup language literals, filtered against detected languages with a warning rather than a failure), `query_suite`, `threat_model`, `runner_type` and `runner_label` (required when `runner_type = "labeled"`).
 
-Top-level `[code_scanning.<name>]` groups configure the
-CodeQL default-setup feature, applied via
-`PATCH /repos/{o}/{r}/code-scanning/default-setup`. Fields:
+The default-setup language enum is `actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`, `javascript-typescript`, `python`, `ruby` and `swift`. This is intentionally narrower than the CodeQL analyzer language list — for example Rust is supported by the CodeQL analyzer but not by default setup. Widen the literal in `package/src/schemas/config.ts` if GitHub extends default-setup support.
 
-- `state` - `"configured" | "not-configured"`
-- `languages` - array of CodeQL default-setup language literals (see
-  enum below); languages not detected in the repository are filtered
-  out at sync time with a warning rather than failing the run
-- `query_suite` - `"default" | "extended"`
-- `threat_model` - `"remote" | "remote_and_local"`
-- `runner_type` - `"standard" | "labeled"`
-- `runner_label` - free-form runner label string; required when
-  `runner_type = "labeled"`
+Groups reference these via `code_scanning: string[]`; multiple references merge last-write-wins via `mergeCodeScanningGroups()`. The PATCH endpoint returns `202 Accepted` and the engine fires it without polling for completion.
 
-```toml
-[code_scanning.baseline]
-state = "configured"
-languages = ["javascript-typescript", "python"]
-query_suite = "extended"
-threat_model = "remote"
-runner_type = "standard"
-```
+## Cleanup configuration
 
-Default-setup language enum (9 values):
-`actions`, `c-cpp`, `csharp`, `go`, `java-kotlin`,
-`javascript-typescript`, `python`, `ruby`, `swift`.
+Cleanup is per group, not global; each group can have its own `[groups.<name>.cleanup]` section. The `CleanupScope` type is a three-way union: `false` (disabled, the default), `true` (delete all undeclared resources) or `{ preserve = [...] }` (delete undeclared except preserved).
 
-This is intentionally narrower than the CodeQL analyzer language list -
-Rust is supported by CodeQL itself but not by default setup as of this
-writing. Add to the literal when GitHub widens default-setup support.
-
-Groups reference code scanning groups via the `code_scanning: string[]`
-field on `[groups.<name>]`. Multiple references are merged last-write-wins
-by `mergeCodeScanningGroups()`. The PATCH endpoint returns
-`202 Accepted`; reposets fires-and-forgets by default and polls in
-verbose mode.
-
-## Cleanup Configuration
-
-Cleanup is per-group (not global). Each group can have its own
-`[groups.<name>.cleanup]` section.
-
-The `CleanupScope` type is a three-way union:
-
-- `false` - cleanup disabled (default)
-- `true` - delete all undeclared resources
-- `{ preserve = ["name1", "name2"] }` - delete undeclared except preserved
-
-Cleanup is organized into nested scopes:
-
-```text
-cleanup
-  secrets
-    actions:      CleanupScope
-    dependabot:   CleanupScope
-    codespaces:   CleanupScope
-    environments: CleanupScope
-  variables
-    actions:      CleanupScope
-    environments: CleanupScope
-  rulesets:       CleanupScope
-  environments:   CleanupScope
-```
-
-All scopes default to `false`. Cleanup runs after sync so newly synced
-items are never deleted.
+Scopes nest as `cleanup.secrets.{actions,dependabot,codespaces,environments}`, `cleanup.variables.{actions,environments}`, `cleanup.rulesets` and `cleanup.environments`. All default to `false`. Cleanup runs after sync so newly synced items are never deleted. Security features and code scanning have no cleanup scope — omission means "leave alone".
 
 ## Credentials
 
@@ -422,63 +227,4 @@ BOT_NAME = "mybot[bot]"
 REGISTRIES = { npm = "https://registry.npmjs.org" }
 ```
 
-If only one profile exists, it is used implicitly. Multiple profiles are
-referenced by name from groups via `credentials = "profile-name"`.
-
-The `[resolve]` section defines named labels in three sub-groups:
-`op` (1Password references), `file` (file paths), `value` (inline
-strings or objects). All three contribute to a flat namespace of
-labels referenced by config templates.
-
-## JSON Schema Generation
-
-Effect Schema definitions generate JSON schemas via `JsonSchemaExporter`
-from xdg-effect (v1.0.0). The generation script
-(`package/lib/scripts/generate-json-schema.ts`) uses the standard
-`generateMany` -> `validateMany` -> `writeMany` pipeline:
-
-1. Calls `JsonSchemaExporter.generateMany()` with schema definitions,
-   root def names, and `$id` URLs
-2. Calls `JsonSchemaValidator.validateMany()` for strict-mode validation
-   (custom extension keywords `x-tombi-*`, `x-taplo` are handled
-   internally by the validator service)
-3. Writes output via `JsonSchemaExporter.writeMany()` to
-   `package/schemas/` (only writes when content changed)
-
-`$id` values (externally hosted on GitHub):
-
-- Config: `https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.config.schema.json`
-- Credentials: `https://raw.githubusercontent.com/spencerbeggs/reposets/main/package/schemas/reposets.credentials.schema.json`
-
-### Schema Annotations
-
-Schemas use two typed annotation helpers from xdg-effect:
-
-- `tombi({ ... })` -- generates `x-tombi-*` annotations for Tombi TOML
-  LSP: `additionalKeyLabel`, `tableKeysOrder`, `arrayValuesOrder`,
-  `arrayValuesOrderBy`, `stringFormats`, `tomlVersion`
-- `taplo({ ... })` -- generates `x-taplo` annotations for Taplo TOML
-  LSP: `initKeys` (scaffolding hints) and `links.key` (documentation
-  URLs)
-
-Both helpers are applied via the `jsonSchema: { ... }` annotation
-property. When a schema needs both, the results are spread together:
-`jsonSchema: { ...tombi({ ... }), ...taplo({ ... }) }`.
-
-Standard annotations (`title`, `description`, `examples`, `default`)
-are set directly on all fields.
-
-### Jsonifiable Type
-
-Schema fields that accept arbitrary JSON-compatible values (settings
-pass-through, inline credential values) use the `Jsonifiable` schema
-from xdg-effect instead of `Schema.Unknown`. This ensures generated
-JSON schemas produce `{}` instead of `{ "$id": "/schemas/unknown" }`
-for those positions. Three files use `Jsonifiable`: `common.ts`
-(resource value kind), `credentials.ts` (resolve value entries), and
-`config.ts` (settings group index signature).
-
-### Dependencies
-
-- `xdg-effect` (^1.0.0) -- `JsonSchemaExporter`, `JsonSchemaValidator`,
-  `Jsonifiable`, `tombi()`, `taplo()` helpers
+A single profile is used implicitly; multiple profiles are referenced by name from groups via `credentials = "profile-name"`. The `[resolve]` section defines named labels in three sub-groups — `op` (1Password references), `file` (file paths) and `value` (inline strings or objects) — that all contribute to one flat namespace referenced by config templates.

--- a/.claude/design/reposets/json-schema.md
+++ b/.claude/design/reposets/json-schema.md
@@ -1,0 +1,46 @@
+---
+module: reposets
+title: JSON Schema Generation
+category: other
+status: current
+completeness: 90
+created: 2026-06-12
+updated: 2026-06-12
+last-synced: 2026-06-12
+related:
+  - config-format.md
+  - services.md
+  - architecture.md
+dependencies: []
+---
+
+## Overview
+
+The Effect Schema definitions that validate `reposets.config.toml` and `reposets.credentials.toml` also generate JSON schemas for editor TOML language servers. This is a build-time subsystem, separate from runtime config loading. The generation script is `package/lib/scripts/generate-json-schema.ts`; output lands in `package/schemas/` and runs ahead of the package builds via the `generate:json-schema` Turbo task. The config TOML format itself is documented in `config-format.md`.
+
+## Generation pipeline
+
+The script uses xdg-effect's `JsonSchemaExporter` and `JsonSchemaValidator` in a `generateMany` -> `validateMany` -> `writeMany` sequence:
+
+1. `generateMany()` produces schemas from the schema definitions, root def names and `$id` URLs.
+2. `validateMany()` runs strict-mode validation; the custom extension keywords (`x-tombi-*`, `x-taplo`) are handled inside the validator service.
+3. `writeMany()` writes to `package/schemas/`, only when content changed.
+
+The `$id` of each schema points at the raw GitHub hosting URL for the corresponding file under `package/schemas/`, so editors can fetch the published schema.
+
+## Annotations
+
+Two typed helpers from xdg-effect attach language-server annotations through the `jsonSchema: { ... }` annotation property:
+
+- `tombi({ ... })` generates `x-tombi-*` annotations for the Tombi TOML LSP (key ordering, array ordering, string formats, TOML version and similar).
+- `taplo({ ... })` generates `x-taplo` annotations for the Taplo TOML LSP (scaffolding `initKeys` and documentation `links.key`).
+
+When a field needs both, the results are spread together. Standard annotations (`title`, `description`, `examples`, `default`) are set directly on fields.
+
+## Jsonifiable type
+
+Schema positions that accept arbitrary JSON-compatible values (settings pass-through and inline credential values) use xdg-effect's `Jsonifiable` schema rather than `Schema.Unknown`, so generated schemas emit `{}` instead of an unknown-schema `$id`. The positions that use it are the resource value kind in `common.ts`, resolve value entries in `credentials.ts` and the settings group index signature in `config.ts`.
+
+## Dependencies
+
+`xdg-effect` provides `JsonSchemaExporter`, `JsonSchemaValidator`, `Jsonifiable`, `tombi()` and `taplo()`.

--- a/.claude/design/reposets/services.md
+++ b/.claude/design/reposets/services.md
@@ -1,348 +1,70 @@
 ---
 module: reposets
 title: Effect Services
+category: architecture
 status: current
-completeness: 95
-last-synced: 2026-04-27
+completeness: 90
+created: 2026-04-21
+updated: 2026-06-12
+last-synced: 2026-06-12
+related:
+  - architecture.md
+  - config-format.md
+  - json-schema.md
+dependencies: []
 ---
+
+## Overview
+
+Six Effect services compose the sync pipeline. Each lives in its own file under `package/src/services/` and ships a Live and a Test layer. This doc records what each service is responsible for, the boundaries between them and the non-obvious decisions — interface shapes and method signatures are authoritative in the source files, not here.
 
 ## ConfigFiles
 
-Declarative config file loading via xdg-effect `ConfigFile.Tag` services.
-Replaces the former `ConfigLoader` service.
+Declarative config loading via xdg-effect `ConfigFile.Tag`. See `package/src/services/ConfigFiles.ts`.
 
-- `ReposetsConfigFile` (`ConfigFile.Tag<Config>`) - config file service
-  with `discover` (find and parse), `load`, `loadOrDefault`, `save`,
-  `update` methods; schema validation via `ConfigSchema`; cross-reference
-  validation via `validateConfigRefs` callback
-- `ReposetsCredentialsFile` (`ConfigFile.Tag<Credentials>`) - credentials
-  file service with same methods; schema validation via
-  `CredentialsSchema`; default XDG save path
-- `makeConfigFilesLive(configFlag: Option<string>)` - factory that builds
-  resolver chains based on the `--config` flag:
-  - `Some(file)` -> prepends `ExplicitPath(flag)`
-  - `Some(directory)` -> prepends `StaticDir({ dir, filename })`
-  - Always appends `UpwardWalk` + `XdgConfigResolver` as fallbacks
-- `ConfigFilesLive` - convenience alias for `makeConfigFilesLive(Option.none())`
-- `validateConfigRefs(config)` - validates all internal cross-references
-  (settings, secrets, variables, rulesets, environments) and collects
-  errors into a single `ConfigError`
+- `ReposetsConfigFile` and `ReposetsCredentialsFile` are `ConfigFile.Tag` services (`discover`, `load`, `loadOrDefault`, `save`, `update`), validated against `ConfigSchema` / `CredentialsSchema`.
+- `makeConfigFilesLive(configFlag)` builds the resolver chain from the `--config` flag: a file flag prepends `ExplicitPath`, a directory flag prepends `StaticDir`, and `UpwardWalk` + `XdgConfigResolver` are always appended as fallbacks. `ConfigFilesLive` is the no-flag alias.
+- `validateConfigRefs(config)` is registered as the config validator; it collects every cross-reference error (settings, secrets, variables, rulesets, environments, security, code_scanning) into a single `ConfigError`.
 
-Implementation: `XdgConfigLive.multi()` with `TomlCodec` and
-`FirstMatch` strategy. Each command provides its own layer via
-`makeConfigFilesLive(config)`. No direct I/O in the service definition.
+The service definition does no direct I/O — it composes xdg-effect's `XdgConfigLive.multi()` with a TOML codec and first-match strategy.
 
 ## OnePasswordClient
 
-Wraps `@1password/sdk` for resolving `op://` secret references.
-
-- `resolve(reference, serviceAccountToken)` - resolve a 1Password reference
-
-Live: dynamically imports `@1password/sdk`, creates client per call.
-Test: `OnePasswordClientTest(stubs)` returns values from a stub map.
+Wraps `@1password/sdk` to resolve `op://` references. The Live layer dynamically imports the SDK and creates a client per call; the Test layer returns values from a stub map. See `package/src/services/OnePasswordClient.ts`.
 
 ## CredentialResolver
 
-Resolves all named labels from a credential profile's `[resolve]` section
-into a flat `Map<string, string>`.
-
-- `resolveAll(profile, basePath)` - resolve all labels from the profile
-
-Depends on `OnePasswordClient` for `op` sources. Built with `Layer.effect`.
-
-Resolution by sub-group:
-
-- `resolve.value` - strings as-is, objects JSON-stringified
-- `resolve.file` - `readFileSync` relative to basePath, trimmed
-- `resolve.op` - delegate to OnePasswordClient (requires op_service_account_token)
-
-All three sub-groups contribute to one flat namespace. Duplicate labels
-across sub-groups are a validation error.
+Resolves every label in a profile's `[resolve]` section into one flat `Map<string, string>`. The three sub-groups — `value` (inline, objects JSON-stringified), `file` (read relative to the config dir, trimmed) and `op` (delegated to `OnePasswordClient`) — share a single namespace, so duplicate labels across sub-groups are a validation error. Depends on `OnePasswordClient`. See `package/src/services/CredentialResolver.ts`.
 
 ## SyncLogger
 
-Tiered output service for the sync pipeline. All sync output flows through
-this service rather than direct console calls. CLI commands use
-`Effect.log`/`Effect.logError` with a custom `CliLogger` (defined in
-the entrypoint) that routes to stdout/stderr.
+Tiered output for the sync pipeline; all sync output flows through it rather than direct console calls. CLI commands use `Effect.log`/`Effect.logError` routed by `CliLogger` instead. See `package/src/services/SyncLogger.ts`.
 
-Methods: `groupStart`, `repoStart`, `repoSkip`, `syncSummary`,
-`settingsApplied`, `cleanupSummary`, `syncOperation`, `syncError`, `finish`
-
-The `syncSummary` resource parameter accepts `"secret" | "variable" |
-"ruleset" | "environment"` to cover environment sync output.
-
-Visibility tiers:
-
-- `silent` - no output
-- `info` - group/repo headers, summary counts, cleanup summaries with names
-- `verbose` - per-operation lines (sync/apply/delete per resource)
-- `debug` - per-operation lines with source info appended
-
-Dry-run: verbs prefixed with "would" (e.g., "would sync" instead of "synced").
-Errors accumulated via `Ref` and reported in `finish()` as an end-of-run
-summary.
-
-Live: `SyncLoggerLive({ dryRun, logLevel, output? })` - `output` Ref is
-for test capture. Test layer uses `logLevel: "silent"` to suppress output.
+Visibility tiers: `silent` (nothing), `info` (group/repo headers, summary and cleanup counts with names), `verbose` (per-operation lines), `debug` (per-operation lines with source info). Dry-run prefixes verbs with "would". Errors accumulate in a `Ref` and are reported in `finish()` as an end-of-run summary. `SyncLoggerLive` accepts an optional `output` Ref for test capture.
 
 ## GitHubClient
 
-Wraps Octokit with typed methods for all GitHub API operations. 30 methods
-organized into five domains: repo-level resources, environments,
-environment-scoped resources, repository security features, and CodeQL
-default setup.
+Octokit wrapper exposing typed methods across five domains: repo-level resources, environments, environment-scoped resources, repository security features and CodeQL default setup. See the service interface and `GitHubClientTest()` recorder in `package/src/services/GitHubClient.ts`. The decisions worth knowing:
 
-### Repo-Level Methods
+- `getOwnerType(owner)` drives org-only field stripping upstream in the SyncEngine.
+- `syncSettings` sends standard fields via REST `repos.update`; `has_sponsorships` and `has_pull_requests` route through a GraphQL `updateRepository` mutation (mapped by the `GRAPHQL_SETTINGS` constant), which resolves the repo `node_id` via `octokit.repos.get()` first. The method strips merge-commit/squash formatting fields when the matching strategy is disabled.
+- The `security_and_analysis` block is folded into the same settings PATCH. `transformSecurityAndAnalysis(value)` (exported for unit testing) wraps each status field as `{ status: "..." }`, rewrites `delegated_bypass_reviewers` under `secret_scanning_delegated_bypass_options.reviewers`, and returns `undefined` when empty so callers omit the field. The status-field set is `SAA_STATUS_FIELDS` in the same file.
+- Repository security features (`vulnerability_alerts`, `automated_security_fixes`, `private_vulnerability_reporting`) each have a `getXxx` probe returning a normalized boolean and a `setXxx` toggle hitting dedicated PUT/DELETE endpoints. The SyncEngine uses the probe to diff before toggling.
+- `updateCodeScanningDefaultSetup` PATCHes the default-setup endpoint, which responds `202 Accepted` and applies asynchronously; the engine fires the request without polling.
+- `listRepoLanguages` returns the language-name keys from `octokit.repos.listLanguages`, used to filter configured CodeQL languages against what GitHub detects.
+- `resolveTeamId(org, slug)` and `resolveRoleId(org, name)` map `delegated_bypass_reviewers` entries to numeric `{ reviewer_id, reviewer_type }`. Both cache per `org:slug` / `org:name` for the GitHubClient instance lifetime. Role IDs are per-org even for predefined roles, so resolution must hit the live API the first time each (org, role) pair appears; an unknown role surfaces as `GitHubApiError` and follows the catch-and-warn path.
 
-- `getOwnerType(owner)` - determine if owner is a User or Organization
-- `syncSecret(owner, repo, name, value, scope)` - encrypt and upsert
-  (actions/dependabot/codespaces)
-- `syncVariable(owner, repo, name, value)` - create or update
-- `syncSettings(owner, repo, settings)` - REST `repos.update` for standard
-  fields; GraphQL `updateRepository` mutation for `has_sponsorships` and
-  `has_pull_requests` (mapped via `GRAPHQL_SETTINGS` constant). The
-  `security_and_analysis` field is folded into the REST PATCH body by the
-  SyncEngine via `transformSecurityAndAnalysis()` (status fields wrapped
-  as `{ status: "enabled" | "disabled" }`; `delegated_bypass_reviewers`
-  rewritten under `secret_scanning_delegated_bypass_options.reviewers`)
-- `syncRuleset(owner, repo, name, payload)` - create or update by name;
-  accepts `Ruleset` schema type directly
-- `listSecrets/listVariables/listRulesets` - query existing resources
-- `deleteSecret/deleteVariable/deleteRuleset` - cleanup operations
-
-### Environment Methods
-
-- `syncEnvironment(owner, repo, name, config)` - create or update a
-  deployment environment (wait_timer, reviewers, deployment_branches)
-- `syncEnvironmentSecret(owner, repo, envName, name, value)` - encrypt
-  and upsert an environment-scoped secret
-- `syncEnvironmentVariable(owner, repo, envName, name, value)` - create
-  or update an environment-scoped variable
-- `listEnvironments` - list all deployment environments for a repo
-- `listEnvironmentSecrets/listEnvironmentVariables` - query environment
-  resources
-- `deleteEnvironment/deleteEnvironmentSecret/deleteEnvironmentVariable` -
-  cleanup operations
-
-### Repository Security Methods
-
-State-probe + toggle pairs for each of the three dedicated PUT/DELETE
-endpoints. Probes are used by the SyncEngine's security-features stage to
-diff current vs. desired state and only call PUT/DELETE on change. All
-return booleans normalized from the underlying API responses.
-
-- `getVulnerabilityAlerts(owner, repo): boolean` -
-  `GET /repos/{o}/{r}/vulnerability-alerts` (404 -> `false`,
-  204 -> `true`)
-- `setVulnerabilityAlerts(owner, repo, enabled): void` -
-  `PUT` (enabled) / `DELETE` (disabled) on the same path
-- `getAutomatedSecurityFixes(owner, repo): boolean` -
-  `GET /repos/{o}/{r}/automated-security-fixes`; reads `data.enabled`
-- `setAutomatedSecurityFixes(owner, repo, enabled): void` -
-  `PUT`/`DELETE /repos/{o}/{r}/automated-security-fixes`
-- `getPrivateVulnerabilityReporting(owner, repo): boolean` -
-  `GET /repos/{o}/{r}/private-vulnerability-reporting`; reads
-  `data.enabled`
-- `setPrivateVulnerabilityReporting(owner, repo, enabled): void` -
-  `PUT`/`DELETE /repos/{o}/{r}/private-vulnerability-reporting`
-
-### Code Scanning Methods
-
-- `updateCodeScanningDefaultSetup(owner, repo, config): void` -
-  `PATCH /repos/{o}/{r}/code-scanning/default-setup`. The endpoint
-  responds `202 Accepted` and applies asynchronously; the SyncEngine
-  sends the request without polling for completion
-
-### Helper Methods
-
-- `listRepoLanguages(owner, repo): string[]` - thin wrapper around
-  `octokit.repos.listLanguages` returning the language-name keys; used to
-  filter configured CodeQL languages against what GitHub detects in the
-  repo
-- `resolveTeamId(org, slug): number` - looks up
-  `GET /orgs/{org}/teams/{slug}` and caches the numeric team id keyed by
-  `org:slug` for the lifetime of the GitHubClient instance. Used to map
-  `delegated_bypass_reviewers[].team` slugs to API-shaped
-  `{ reviewer_id, reviewer_type: "TEAM" }` entries during settings sync
-- `resolveRoleId(org, name): number` - looks up
-  `GET /orgs/{org}/organization-roles`, scans the returned roles for a
-  match on the `name` field, and caches the numeric role id keyed by
-  `org:name`. Used to map `delegated_bypass_reviewers[].role` names to
-  API-shaped `{ reviewer_id, reviewer_type: "ROLE" }` entries. Role IDs
-  are per-org even for predefined roles, so the resolution must happen
-  against the live API for every (org, role) pair the first time they
-  appear; failures (unknown role name) are surfaced as `GitHubApiError`
-  and trigger the standard catch-and-warn path so the rest of the sync
-  proceeds
-
-### `transformSecurityAndAnalysis` helper
-
-Exported alongside the service interface for direct unit testing.
-`transformSecurityAndAnalysis(value)` translates the user-facing
-`security_and_analysis` config block into the shape the GitHub REST API
-expects on `PATCH /repos/{o}/{r}`:
-
-- Each known status field (members of the `SAA_STATUS_FIELDS` set:
-  `advanced_security`, `code_security`, `secret_scanning`,
-  `secret_scanning_push_protection`,
-  `secret_scanning_ai_detection`,
-  `secret_scanning_non_provider_patterns`,
-  `secret_scanning_delegated_alert_dismissal`,
-  `secret_scanning_delegated_bypass`,
-  `dependabot_security_updates`) wraps its `"enabled" | "disabled"`
-  value as `{ status: "..." }`
-- `delegated_bypass_reviewers` is rewritten under
-  `secret_scanning_delegated_bypass_options.reviewers` (entries are
-  expected to already carry numeric `reviewer_id` and `reviewer_type`;
-  team-slug resolution happens in the SyncEngine before calling the
-  transform)
-- Returns `undefined` when the result is empty so callers can omit the
-  field cleanly from the PATCH body
-
-### GraphQL Settings
-
-The `GRAPHQL_SETTINGS` constant maps config keys to GraphQL mutation
-fields. Settings matching these keys are routed through a
-`updateRepository` GraphQL mutation instead of the REST API:
-
-- `has_sponsorships` -> `hasSponsorshipsEnabled`
-- `has_pull_requests` -> `hasPullRequestsEnabled`
-
-The mutation resolves the repository `node_id` via `octokit.repos.get()`
-before executing.
-
-### Settings Sanitization
-
-The `syncSettings` method strips merge commit config when the strategy is
-disabled: if `allow_merge_commit` is false, `merge_commit_title` and
-`merge_commit_message` are removed from the payload (same for squash).
-
-Secret scopes: `actions`, `dependabot`, `codespaces` - each routes to the
-appropriate Octokit API namespace. The `SecretScope` type is
-`"actions" | "dependabot" | "codespaces"`.
-
-Live: `GitHubClientLive(token)` creates an Octokit instance per token; the
-`teamIdCache` (Map<string, number> keyed by `org:slug`) is per-instance.
-Test: `GitHubClientTest()` returns `{ layer, calls() }` recorder covering
-all 30 methods.
+`GitHubClientLive(token)` creates one Octokit instance per token; the team/role caches are per instance.
 
 ## SyncEngine
 
-Orchestrates the full sync workflow. Depends on `GitHubClient`,
-`CredentialResolver`, and `SyncLogger`.
+Orchestrates the full workflow; depends on `GitHubClient`, `CredentialResolver` and `SyncLogger`. Entry point `syncAll(config, credentials, options)` with options `dryRun`, `noCleanup`, `groupFilter`, `repoFilter` and `configDir`. The stage order is described in `architecture.md`; the per-stage detail lives in `package/src/services/SyncEngine.ts`. The decisions worth recording:
 
-- `syncAll(config, credentials, options)` - main entry point
+- Settings from referenced groups merge, and each group's `security_and_analysis` block merges separately via `mergeSecurityAndAnalysis()` (last-write-wins). On personal accounts `ORG_ONLY_SAA_FIELDS` are stripped; on org accounts `delegated_bypass_reviewers` team slugs and role names resolve to numeric reviewer IDs before the merged block is reinjected for the PATCH.
+- `mergeSecurityGroups()` and `mergeCodeScanningGroups()` merge `[security.*]` and `[code_scanning.*]` references last-write-wins, leaving undefined keys as "leave alone". After the security merge the engine detects the `automated_security_fixes = true` with `vulnerability_alerts = false` contradiction that a single group's schema rejects but merging can recreate; if found it logs an error and skips the security stage for those repos rather than letting GitHub return 422.
+- Rulesets are collected from config, normalized via `normalizeRuleset()` and have `{ resolved }` references substituted from the credential map (coerced to integers where needed).
+- Cleanup is computed per group (no global merge, defaults to all-off) and runs last, respecting the three-way `CleanupScope` preserve lists. Ruleset cleanup skips org-level rulesets whose `source_type !== "Repository"`.
 
-Flow per group:
+### Language mapping
 
-1. Resolve owner (group override or config default)
-2. Resolve credential profile (explicit or implicit single profile)
-3. Resolve all credential labels via `CredentialResolver.resolveAll()`
-   into a flat `Map<string, string>`
-4. Detect ownership type via `GitHubClient.getOwnerType()` (defaults to
-   `"User"` on API failure); used to strip org-only fields
-5. Resolve secret groups by scope: `actions`, `dependabot`, `codespaces`
-   each get their own resolved map
-6. Resolve variable groups from `variables.actions` references
-7. Collect rulesets from config; normalize shorthands via
-   `normalizeRuleset()`; substitute `{ resolved }` references with values
-   from the credential map, coercing to integers where needed
-8. Resolve environment references from `group.environments` array
-9. Resolve environment-scoped secrets from `group.secrets.environments`
-   mapping (env name -> secret group refs)
-10. Resolve environment-scoped variables from `group.variables.environments`
-    mapping (env name -> variable group refs)
-11. Merge settings from referenced setting groups; pull each group's
-    `security_and_analysis` block aside and merge those separately via
-    `mergeSecurityAndAnalysis()` (last-write-wins). Strip `ORG_ONLY_SAA_FIELDS`
-    (`secret_scanning_delegated_alert_dismissal`,
-    `secret_scanning_delegated_bypass`, `delegated_bypass_reviewers`) on
-    personal accounts; on org accounts, resolve each
-    `delegated_bypass_reviewers[].team` slug to a numeric `reviewer_id`
-    via `GitHubClient.resolveTeamId()` and each `delegated_bypass_reviewers[].role`
-    name to a numeric role id via `GitHubClient.resolveRoleId()`. Both
-    resolvers cache results per `org:slug` and `org:name` for the
-    lifetime of the GitHubClient instance. Resolved entries are rewritten
-    to `{ reviewer_id, reviewer_type: "TEAM" | "ROLE" }`. Inject the
-    resolved block back into `mergedSettings` under
-    `security_and_analysis` so it rides along with the existing
-    `syncSettings` PATCH (where `transformSecurityAndAnalysis()` reshapes
-    it for the API)
-12. Merge `[security.*]` groups via `mergeSecurityGroups()` and
-    `[code_scanning.*]` groups via `mergeCodeScanningGroups()` -
-    last-write-wins across all references; missing keys remain undefined
-    so they're "leave alone" at sync time. After merging, detect the
-    cross-field contradiction (`automated_security_fixes = true` paired
-    with `vulnerability_alerts = false`) that `SecurityGroupSchema`
-    rejects in a single group but that merging can recreate; if found,
-    the security stage logs an error and is skipped for the affected
-    repos rather than letting GitHub return 422
-13. Compute per-group cleanup config (no global merge; defaults to all-off)
-14. For each repo (skipping mutations in dry-run):
-    - Sync settings (merged settings + folded `security_and_analysis`)
-    - Security features stage (inline): for each of `vulnerability_alerts`,
-      `automated_security_fixes`, `private_vulnerability_reporting`, probe
-      current state via the corresponding `getXxx` method and call PUT or
-      DELETE only when the desired value differs
-    - Code scanning stage (inline): filter merged
-      `code_scanning.languages[]` against languages detected by
-      `listRepoLanguages` (mapped through the `REPO_LANG_TO_CODEQL`
-      table; `actions` always passes through), then call
-      `updateCodeScanningDefaultSetup`. Languages not detected emit a
-      `skip` log line at info/verbose levels rather than failing
-    - Sync environments (must exist before scoped resources)
-    - Sync secrets by scope (actions/dependabot/codespaces)
-    - Sync environment secrets per environment
-    - Sync variables (actions scope)
-    - Sync environment variables per environment
-    - Sync rulesets (fully resolved/normalized `Ruleset` objects)
-15. Cleanup phase per scope: delete undeclared resources respecting
-    preserve lists from the three-way `CleanupScope` union
-    - Actions/dependabot/codespaces secrets
-    - Environment secrets (per environment)
-    - Actions variables
-    - Environment variables (per environment)
-    - Rulesets (skips org-level with `source_type !== "Repository"`)
-    - Environments
-
-Options: `dryRun`, `noCleanup`, `groupFilter`, `repoFilter`, `configDir`
-
-### Merge Helpers
-
-Three internal helpers implement last-write-wins merging across reference
-lists in declaration order:
-
-- `mergeSecurityAndAnalysis(blocks)` - merges
-  `SecurityAndAnalysis | undefined` blocks pulled from each referenced
-  setting group; returns `undefined` when no block contributed any keys
-  so the entire `security_and_analysis` field can be omitted from the
-  PATCH
-- `mergeSecurityGroups(groups)` - merges `SecurityGroup` toggles from
-  `[security.*]` references; only keeps boolean values, so partial
-  configurations cleanly carry through
-- `mergeCodeScanningGroups(groups)` - merges `CodeScanningGroup` configs
-  from `[code_scanning.*]` references; preserves any defined keys
-  (state/languages/query_suite/etc.) and lets undefined keys fall through
-  as "leave alone"
-
-### Language Mapping
-
-`REPO_LANG_TO_CODEQL` (defined at the top of `SyncEngine.ts`) maps repo
-language names (as returned by `octokit.repos.listLanguages`) onto the
-default-setup language enum:
-
-- `JavaScript`, `TypeScript` -> `javascript-typescript`
-- `C`, `C++` -> `c-cpp`
-- `C#` -> `csharp`
-- `Go` -> `go`
-- `Java`, `Kotlin` -> `java-kotlin`
-- `Python` -> `python`
-- `Ruby` -> `ruby`
-- `Swift` -> `swift`
-
-Languages outside the map are dropped from the detected set; the
-code scanning stage uses this set to decide whether a configured
-CodeQL language should be passed through or skipped with a warning. The
-`actions` pseudo-language always passes through unchanged because it
-isn't a repo language at all.
+`REPO_LANG_TO_CODEQL` (top of `SyncEngine.ts`) maps repo language names from `octokit.repos.listLanguages` onto the CodeQL default-setup enum. Languages outside the map are dropped from the detected set; the code-scanning stage uses that set to decide whether a configured CodeQL language passes through or is skipped with a warning. The `actions` pseudo-language always passes through because it is not a repo language. See `config-format.md` for the default-setup enum.

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pkgs/generators/test.ts
 test.ts
 .claude/settings.local.json
 .claude/plans/
+.claude/cache/
 **/coverage-debug
 .claude/plugins-debug.log
 .playwright-mcp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,12 @@ code in this repository.
   `@./.claude/design/reposets/architecture.md`
 - Effect services API:
   `@./.claude/design/reposets/services.md`
-- Configuration format and schemas:
+- Configuration file format:
   `@./.claude/design/reposets/config-format.md`
 - CLI commands and options:
   `@./.claude/design/reposets/cli.md`
+- JSON schema generation (build-time):
+  `@./.claude/design/reposets/json-schema.md`
 
 Load the relevant design doc when working on that subsystem. Do NOT load
 all of them at once.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js >= 20
+- Node.js (version declared in the `engines` field of `package/package.json`)
 - pnpm (version managed via `packageManager` field — use corepack or install directly)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -22,26 +22,26 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.
 
-## Installation
+## Install
 
-```sh
+```bash
 npm install -g reposets
 ```
 
 Alternative (no install):
 
-```sh
+```bash
 npx reposets <command>
 ```
 
-Requires Node.js >= 20.
+Requires the Node.js version declared in [`package/package.json`](package/package.json).
 
-## Quick Start
+## Quick start
 
 1. Run `reposets init` to scaffold config files.
 2. Add a credential profile:
 
-   ```sh
+   ```bash
    reposets credentials create --profile personal --github-token ghp_...
    ```
 
@@ -61,19 +61,19 @@ Requires Node.js >= 20.
 
 4. Validate your config:
 
-   ```sh
+   ```bash
    reposets validate
    ```
 
 5. Preview changes without applying them:
 
-   ```sh
+   ```bash
    reposets sync --dry-run
    ```
 
 6. Apply the config:
 
-   ```sh
+   ```bash
    reposets sync
    ```
 
@@ -104,7 +104,7 @@ Full reference guides are in the [docs/](docs/) folder:
 - [Cleanup](docs/cleanup.md) - automatic cleanup of undeclared resources
 - [Token Permissions](docs/token-permissions.md) - GitHub PAT setup guide
 
-## Project Structure
+## Project structure
 
 ```text
 package/               # reposets CLI package (published to npm + GitHub Packages)
@@ -118,9 +118,9 @@ lib/configs/           # Shared dev config (commitlint, lint-staged, markdownlin
 
 ## Development
 
-Prerequisites: Node.js >= 20, pnpm.
+Prerequisites: Node.js (version in [`package/package.json`](package/package.json)) and pnpm.
 
-```sh
+```bash
 pnpm install           # Install dependencies
 pnpm run build         # Build all packages
 pnpm run test          # Run tests
@@ -135,4 +135,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](LICENSE)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,17 +6,17 @@ Rather than clicking through repository settings one by one, reposets lets you m
 
 ## Prerequisites
 
-- Node.js >= 20
+- Node.js (version declared in the package `engines` field)
 
-## Installation
+## Install
 
-```sh
+```bash
 npm install -g reposets
 # or run without installing:
 npx reposets <command>
 ```
 
-## Getting Started
+## Getting started
 
 1. Install reposets (see above)
 2. Create a GitHub fine-grained personal access token with the [required permissions](token-permissions.md)

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"types:check": "tsgo --noEmit"
 	},
 	"devDependencies": {
-		"@savvy-web/silk": "^0.3.1",
+		"@savvy-web/silk": "^0.5.0",
 		"@savvy-web/vitest": "^1.4.0",
 		"reposets": "workspace:*",
 		"tsx": "catalog:silk"

--- a/package/README.md
+++ b/package/README.md
@@ -1,8 +1,9 @@
 # reposets
 
-[![npm version](https://img.shields.io/npm/v/reposets)](https://www.npmjs.com/package/reposets)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
+[![npm](https://img.shields.io/npm/v/reposets?label=npm&color=cb3837)](https://www.npmjs.com/package/reposets)
+[![License: MIT](https://img.shields.io/badge/License-MIT-4caf50.svg)](https://opensource.org/licenses/MIT)
+[![Node.js %3E%3D24.11.0](https://img.shields.io/badge/Node.js-%3E%3D24.11.0-5fa04e.svg)](https://nodejs.org/)
+[![TypeScript 6.0](https://img.shields.io/badge/TypeScript-6.0-3178c6.svg)](https://www.typescriptlang.org/)
 
 Declarative GitHub repository management. Define your repo settings, secrets, variables, rulesets, deployment environments, advanced security toggles, and CodeQL default setup in a TOML config file, then apply them across all your repositories with a single command.
 
@@ -22,26 +23,26 @@ Managing repository settings by hand doesn't scale. When you have dozens of repo
 - **Cleanup policies** — Automatically remove undeclared resources per scope with optional preserve lists, so your repos converge to the declared state.
 - **Dry-run and validation** — Preview changes before applying, validate config locally without touching the GitHub API, and catch typos with built-in diagnostics.
 
-## Installation
+## Install
 
-```sh
+```bash
 npm install -g reposets
 ```
 
 Alternative (no install):
 
-```sh
+```bash
 npx reposets <command>
 ```
 
-Requires Node.js >= 20.
+Requires the Node.js version shown in the badge above.
 
-## Quick Start
+## Quick start
 
 1. Run `reposets init` to scaffold config files.
 2. Add a credential profile:
 
-   ```sh
+   ```bash
    reposets credentials create --profile personal --github-token ghp_...
    ```
 
@@ -61,19 +62,19 @@ Requires Node.js >= 20.
 
 4. Validate your config:
 
-   ```sh
+   ```bash
    reposets validate
    ```
 
 5. Preview changes without applying them:
 
-   ```sh
+   ```bash
    reposets sync --dry-run
    ```
 
 6. Apply the config:
 
-   ```sh
+   ```bash
    reposets sync
    ```
 
@@ -105,7 +106,7 @@ Config lookup order (first match wins):
 
 See the [docs/](https://github.com/spencerbeggs/reposets/tree/main/docs) folder for full reference on configuration, credentials, secrets, rulesets, environments, cleanup, and token setup.
 
-## Token Permissions
+## Token permissions
 
 reposets requires a fine-grained personal access token with:
 
@@ -137,4 +138,4 @@ Full reference guides are available in the [`docs/`](https://github.com/spencerb
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](LICENSE)

--- a/package/package.json
+++ b/package/package.json
@@ -56,12 +56,12 @@
 		"@octokit/rest": "^22.0.1",
 		"blakejs": "^1.2.1",
 		"effect": "catalog:silk",
-		"smol-toml": "^1.6.1",
+		"smol-toml": ">=1.6.1",
 		"tweetnacl": "^1.0.3",
 		"xdg-effect": "^1.0.1"
 	},
 	"devDependencies": {
-		"@savvy-web/bundler": "^0.4.0",
+		"@savvy-web/bundler": "^0.4.1",
 		"@types/node": "catalog:silk",
 		"@typescript/native-preview": "catalog:silk",
 		"tsx": "catalog:silk",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,11 +67,11 @@ importers:
   .:
     devDependencies:
       '@savvy-web/silk':
-        specifier: ^0.3.1
-        version: 0.3.1(87e307880005587b27ac304b700e15c5)
+        specifier: ^0.5.0
+        version: 0.5.0(6a89db3ef5da3f8a4cedb9b17924f5f1)
       '@savvy-web/vitest':
         specifier: ^1.4.0
-        version: 1.5.0(5f8fe0ae523e61154d10cde666a90f4a)
+        version: 1.5.0(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest-agent-reporter@1.3.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8))(vitest@4.1.8)
       reposets:
         specifier: workspace:*
         version: link:package/dist/npm
@@ -113,8 +113,8 @@ importers:
         version: 1.0.1(f7d28b62699a48851606e8a2f26fd5c0)
     devDependencies:
       '@savvy-web/bundler':
-        specifier: ^0.4.0
-        version: 0.4.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(ajv@8.18.0)(effect@3.21.3)(tsx@4.22.4)(typescript@6.0.3)
+        specifier: ^0.4.1
+        version: 0.4.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(effect@3.21.3)(tsx@4.22.4)(typescript@6.0.3)
       '@types/node':
         specifier: catalog:silk
         version: 25.9.3
@@ -1118,49 +1118,49 @@ packages:
   '@rushstack/ts-command-line@5.3.9':
     resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
 
-  '@savvy-web/bundler@0.4.0':
-    resolution: {integrity: sha512-CBW52CD5uybxfoyLOiJ497iN0jh9tWdG35mfXsDLiDClTJVGfIK+nzWKWrLTyEgyQFV2n/LodzMH+rMSUlC5gQ==}
+  '@savvy-web/bundler@0.4.1':
+    resolution: {integrity: sha512-wcTT4L4BfW8AdL6/4tPWRdR0jf1+qjUBCBaVw+kAs1RgfZOl0VUM31NGbszyRp0ZYG+W5rnE7punOIZX9RD0YQ==}
     peerDependencies:
       effect: '>=3.21.0'
 
-  '@savvy-web/cli@0.3.1':
-    resolution: {integrity: sha512-WMms4BX7493yxKNGHWP1gkG1ZKjdOxwdbIaR4O8q/ksijTHS5q6A/LzkBYKB+F3br6n2p3SyF6FetrkqRPOoGA==}
+  '@savvy-web/cli@0.5.0':
+    resolution: {integrity: sha512-qmw5FT+t5yy6RCz8PMnXK6+OedQXb+rEnpfhGbTxIH7gTf1FA5avdBZs4/xydHPrNygJXEGrRM0tFN+OdmhmYw==}
     hasBin: true
 
-  '@savvy-web/mcp@0.3.1':
-    resolution: {integrity: sha512-9YsGkEvMgQw3jqTDbxrP0fxerpOSdk3mraDU4SbO3O1JExxMFIm6ajT03hZZ8VJ1znrogPTsAIW01omBGlImjQ==}
+  '@savvy-web/mcp@0.5.0':
+    resolution: {integrity: sha512-3ryZ1Ph2ypBkKDWlo14SyOj+PxLHH+PHbV/XUP5K2asra4mJDyhDEp9L3K1XUkPD41YAOAYqQv0nY65Njt/73g==}
     hasBin: true
 
-  '@savvy-web/silk-effects@0.6.1':
-    resolution: {integrity: sha512-FFhU7t5FpRh2kDxOxWst6KEHeXF1VvoAqIZSIEudBHkMdG5pCz1eUP6PiJFWZqVpuEEVh+dkejl6VFSwI9u7YQ==}
+  '@savvy-web/silk-effects@1.1.0':
+    resolution: {integrity: sha512-msoViM7wtz7apPZwXiCMOevs8RTLzy2DFvAnGB4M4kYObdP3q1iH+M5o7M/Y9qnriqgLxRu3e+SCcPDkLAw3EQ==}
     peerDependencies:
       '@effect/platform': '>=0.96.0'
       effect: '>=3.21.0'
 
-  '@savvy-web/silk@0.3.1':
-    resolution: {integrity: sha512-7ZsfVBA6Oha0DL2/yZj9Q4dR10ZLaRLI8/kcZaXkYyt41dFm3RyCe+VVoQrzF8vevUaEcQ8sKX8MXHNcGUEXsA==}
+  '@savvy-web/silk@0.5.0':
+    resolution: {integrity: sha512-JrIc44GK5D4aunfpgPZV+PD/8ndfjt9WKyU0QZOrL3ECpYpyCb0zcWtdtQPOdlSqi6Zd+j6tYOAEgiqBCsiCGQ==}
     peerDependencies:
       '@biomejs/biome': 2.4.16
       '@changesets/cli': ^2.31.0
       '@commitlint/cli': ^21.0.1
       '@commitlint/config-conventional': ^21.0.2
-      '@savvy-web/cli': 0.3.1
-      '@savvy-web/mcp': 0.3.1
+      '@savvy-web/cli': 0.5.0
+      '@savvy-web/mcp': 0.5.0
       '@types/node': ^25.9.0
       '@typescript/native-preview': ^7.0.0-dev.20260513.1
       commitizen: ^4.3.0
-      husky: ^9.1.0
-      lint-staged: ^17.0.5
+      husky: ^9.1.7
+      lint-staged: ^17.0.7
       markdownlint-cli2: ^0.22.1
       markdownlint-cli2-formatter-codequality: ^0.0.7
-      turbo: ^2.9.16
+      turbo: ^2.9.18
       typescript: ^6.0.0
     peerDependenciesMeta:
       '@biomejs/biome':
         optional: true
 
-  '@savvy-web/tsdown-plugins@0.4.0':
-    resolution: {integrity: sha512-v994psUQQi9G/U7NL01HJpnLx2KwtqWG0wNvw7CdYdDiIsNhvtuHS+VACndR6opyEO/sJ51DDz1JMPbUq9oZxA==}
+  '@savvy-web/tsdown-plugins@0.4.1':
+    resolution: {integrity: sha512-AAYSOP31LL31alZYEZAxXbtWNIX8/eTYQabau87DvT2oNl5s9eTWCdrLODlFUXJyNQ6Lu3UrgnrB0HAJirDW6g==}
     peerDependencies:
       effect: '>=3.21.0'
 
@@ -2455,6 +2455,17 @@ packages:
       ajv:
         optional: true
 
+  json-schema-effect@0.2.2:
+    resolution: {integrity: sha512-79LOftpB8/mD0LQEqKmrKmlfHXVYdT7f+58k9H+zQ4zLoTpPR2DurXJUhLsB7CMygre5VpGYjSRltfk18HoS8g==}
+    engines: {node: '>=24.11.0'}
+    peerDependencies:
+      '@effect/platform': catalog:silkPeers
+      '@effect/platform-node': catalog:silkPeers
+      effect: catalog:silkPeers
+    peerDependenciesMeta:
+      '@effect/platform-node':
+        optional: true
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -3317,11 +3328,6 @@ packages:
 
   sort-object-keys@2.1.0:
     resolution: {integrity: sha512-SOiEnthkJKPv2L6ec6HMwhUcN0/lppkeYuN1x63PbyPRrgSPIuBJCiYxYyvWRTtjMlOi14vQUCGUJqS6PLVm8g==}
-
-  sort-package-json@3.7.1:
-    resolution: {integrity: sha512-ssk1HG7whF8N/T1IsNAQrtHG5Cbdi0rAgRJZXYBr9hF5xaHnBNzUx/W6LcthEW7FhOwvZssbESZuO+GxssqAyA==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   sort-package-json@4.0.0:
     resolution: {integrity: sha512-6aYOlYI9AWioZ+rzu+4zKLmoFqJP0/fHDxrd7X04yqEibikY+5YVF0EYlyGn4v6X2PJY7yAUWV7oeP+i5rOm/g==}
@@ -4191,9 +4197,8 @@ snapshots:
       effect: 3.21.3
       uuid: 11.1.1
 
-  '@effect/platform-node-shared@0.59.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)':
+  '@effect/platform-node-shared@0.59.0(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)':
     dependencies:
-      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/platform': 0.96.1(effect@3.21.3)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
@@ -4219,11 +4224,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)':
+  '@effect/platform-node@0.106.0(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)':
     dependencies:
-      '@effect/cluster': 0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/platform': 0.96.1(effect@3.21.3)
-      '@effect/platform-node-shared': 0.59.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
+      '@effect/platform-node-shared': 0.59.0(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/rpc': 0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       effect: 3.21.3
@@ -4840,9 +4844,9 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@savvy-web/bundler@0.4.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(ajv@8.18.0)(effect@3.21.3)(tsx@4.22.4)(typescript@6.0.3)':
+  '@savvy-web/bundler@0.4.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(effect@3.21.3)(tsx@4.22.4)(typescript@6.0.3)':
     dependencies:
-      '@savvy-web/tsdown-plugins': 0.4.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(ajv@8.18.0)(effect@3.21.3)
+      '@savvy-web/tsdown-plugins': 0.4.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(effect@3.21.3)
       '@tsdown/exe': 0.22.2(tsdown@0.22.2)
       effect: 3.21.3
       tsdown: 0.22.2(@tsdown/exe@0.22.2)(@typescript/native-preview@7.0.0-dev.20260612.1)(tsx@4.22.4)(typescript@6.0.3)
@@ -4857,7 +4861,6 @@ snapshots:
       - '@types/node'
       - '@typescript/native-preview'
       - '@vitejs/devtools'
-      - ajv
       - bufferutil
       - oxc-resolver
       - publint
@@ -4868,12 +4871,12 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@savvy-web/cli@0.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))':
+  '@savvy-web/cli@0.5.0(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))':
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/platform': 0.96.1(effect@3.21.3)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
-      '@savvy-web/silk-effects': 0.6.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
+      '@savvy-web/silk-effects': 1.1.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       effect: 3.21.3
       jsonc-effect: 0.2.1(effect@3.21.3)
       workspaces-effect: 1.2.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
@@ -4889,12 +4892,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/mcp@0.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))':
+  '@savvy-web/mcp@0.5.0(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))':
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.3)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      '@savvy-web/silk-effects': 0.6.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
+      '@savvy-web/silk-effects': 1.1.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       effect: 3.21.3
       fuse.js: 7.4.2
       workspaces-effect: 1.2.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
@@ -4909,7 +4912,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@savvy-web/silk-effects@0.6.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)':
+  '@savvy-web/silk-effects@1.1.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)':
     dependencies:
       '@changesets/get-github-info': 0.8.0
       '@effect/platform': 0.96.1(effect@3.21.3)
@@ -4923,7 +4926,7 @@ snapshots:
       remark-stringify: 11.0.0
       semver-effect: 0.2.1(effect@3.21.3)
       shell-quote: 1.8.4
-      sort-package-json: 3.7.1
+      sort-package-json: 4.0.0
       tinyglobby: 0.2.17
       unified: 11.0.5
       unified-lint-rule: 3.0.1
@@ -4936,32 +4939,39 @@ snapshots:
       - encoding
       - supports-color
 
-  '@savvy-web/silk@0.3.1(87e307880005587b27ac304b700e15c5)':
+  '@savvy-web/silk@0.5.0(6a89db3ef5da3f8a4cedb9b17924f5f1)':
     dependencies:
       '@changesets/cli': 2.31.0(@types/node@25.9.3)
       '@commitlint/cli': 21.0.2(@types/node@25.9.3)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional': 21.0.2
-      '@savvy-web/cli': 0.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))
-      '@savvy-web/mcp': 0.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))
+      '@effect/platform': 0.96.1(effect@3.21.3)
+      '@savvy-web/cli': 0.5.0(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))
+      '@savvy-web/mcp': 0.5.0(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))
+      '@savvy-web/silk-effects': 1.1.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       '@types/node': 25.9.3
       '@typescript/native-preview': 7.0.0-dev.20260612.1
       commitizen: 4.3.1(@types/node@25.9.3)(typescript@6.0.3)
+      effect: 3.21.3
       husky: 9.1.7
       lint-staged: 17.0.7
       markdownlint-cli2: 0.22.1
       markdownlint-cli2-formatter-codequality: 0.0.7(markdownlint-cli2@0.22.1)
+      semver: 7.8.4
       turbo: 2.9.18
       typescript: 6.0.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
-  '@savvy-web/tsdown-plugins@0.4.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(ajv@8.18.0)(effect@3.21.3)':
+  '@savvy-web/tsdown-plugins@0.4.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@types/node@25.9.3)(effect@3.21.3)':
     dependencies:
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@microsoft/api-extractor': 7.58.8(@types/node@25.9.3)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
       deep-equal: 2.2.3
       effect: 3.21.3
-      json-schema-effect: 0.2.1(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(ajv@8.18.0)(effect@3.21.3)
+      json-schema-effect: 0.2.2(@effect/platform-node@0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       picocolors: 1.1.1
       sort-package-json: 4.0.0
       std-env: 4.1.0
@@ -4973,18 +4983,17 @@ snapshots:
       - '@effect/rpc'
       - '@effect/sql'
       - '@types/node'
-      - ajv
       - bufferutil
       - utf-8-validate
 
-  '@savvy-web/vitest@1.5.0(5f8fe0ae523e61154d10cde666a90f4a)':
+  '@savvy-web/vitest@1.5.0(@types/node@25.9.3)(@typescript/native-preview@7.0.0-dev.20260612.1)(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest-agent-reporter@1.3.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8))(vitest@4.1.8)':
     dependencies:
       '@types/node': 25.9.3
       '@typescript/native-preview': 7.0.0-dev.20260612.1
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
       typescript: 6.0.3
       vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.9.0))
-      vitest-agent-reporter: 1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8)
+      vitest-agent-reporter: 1.3.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8)
       workspace-tools: 0.41.7
 
   '@simple-libs/child-process-utils@1.0.2':
@@ -6254,14 +6263,6 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
-  json-schema-effect@0.2.1(@effect/platform-node@0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(ajv@8.18.0)(effect@3.21.3):
-    dependencies:
-      '@effect/platform': 0.96.1(effect@3.21.3)
-      effect: 3.21.3
-    optionalDependencies:
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
-      ajv: 8.18.0
-
   json-schema-effect@0.2.1(@effect/platform-node@0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(ajv@8.18.0)(effect@3.21.3):
     dependencies:
       '@effect/platform': 0.96.1(effect@3.21.3)
@@ -6269,6 +6270,14 @@ snapshots:
     optionalDependencies:
       '@effect/platform-node': 0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       ajv: 8.18.0
+
+  json-schema-effect@0.2.2(@effect/platform-node@0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3):
+    dependencies:
+      '@effect/platform': 0.96.1(effect@3.21.3)
+      ajv: 8.20.0
+      effect: 3.21.3
+    optionalDependencies:
+      '@effect/platform-node': 0.107.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
 
   json-schema-traverse@1.0.0: {}
 
@@ -7368,16 +7377,6 @@ snapshots:
 
   sort-object-keys@2.1.0: {}
 
-  sort-package-json@3.7.1:
-    dependencies:
-      detect-indent: 7.0.2
-      detect-newline: 4.0.1
-      git-hooks-list: 4.2.1
-      is-plain-obj: 4.1.0
-      semver: 7.8.4
-      sort-object-keys: 2.1.0
-      tinyglobby: 0.2.17
-
   sort-package-json@4.0.0:
     dependencies:
       detect-indent: 7.0.2
@@ -7664,11 +7663,11 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest-agent-reporter@1.3.1(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8):
+  vitest-agent-reporter@1.3.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@vitest/coverage-v8@4.1.8)(typescript@6.0.3)(vitest@4.1.8):
     dependencies:
       '@effect/cli': 0.75.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/printer-ansi@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(@effect/printer@0.49.0(@effect/typeclass@0.40.0(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/platform': 0.96.1(effect@3.21.3)
-      '@effect/platform-node': 0.106.0(@effect/cluster@0.58.2(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/workflow@0.18.2(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
+      '@effect/platform-node': 0.106.0(@effect/platform@0.96.1(effect@3.21.3))(@effect/rpc@0.75.1(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@effect/sql': 0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3)
       '@effect/sql-sqlite-node': 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(@effect/sql@0.51.1(@effect/experimental@0.60.0(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(@effect/platform@0.96.1(effect@3.21.3))(effect@3.21.3))(effect@3.21.3)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ autoInstallPeers: true
 configDependencies:
   "@savvy-web/pnpm-plugin-silk": 0.14.6+sha512-Jvy0zyxznw3h5B7tXOZMj7XwfphvJukj4bc3WZvEGoarosfDfAzqu6QslcDrENpoxvbe/jJDmnT/tkChKx/T7g==
 loglevel: info
+minimumReleaseAgeExclude:
+  - json-schema-effect@0.2.2


### PR DESCRIPTION
## Summary

A documentation grooming pass across the `reposets` module plus an incidental dependency bump. No application source, public API, CLI command, config schema, or runtime behavior changed.

### Design docs (`.claude/design/reposets/`)
- Restyled and resynced all docs against the current implementation; pruned stale context (dead `ConfigLoader` references, exact test/method counts, exhaustive enumerations replaced with source pointers).
- Split JSON schema generation out of `config-format.md` into a new `json-schema.md`; wired bidirectional cross-references.
- Corrected a factual drift (code scanning is fire-and-forget, not polling).
- Updated the root `CLAUDE.md` design-doc pointers and seeded `.claude/design/refs.json`.

### User-facing docs
- Normalized badges (brand colors, added Node.js runtime badge) and heading case across `README.md`, `docs/README.md`, `package/README.md`, `CONTRIBUTING.md`.
- Fixed a stale `Node.js >= 20` requirement (actual engine is `>=24.11.0`); `sh` fences → `bash`.

### Dependencies
- Bumped `@savvy-web/silk` 0.3.1→0.5.0 and `@savvy-web/bundler` 0.4.0→0.4.1 (dev/build tooling); widened `smol-toml` range to `>=1.6.1` (resolved version unchanged); added a `json-schema-effect@0.2.2` minimum-release-age exclude.
- Ignored `.claude/cache/`.

## Changeset

None — all changes fall under exclusion rules (internal design docs, AI context, behavior-neutral config, doc-only fixes, routine dependency churn). The `smol-toml` range widening does not move the resolved version.

Signed-off-by: C. Spencer Beggs <spencer@beggs.codes>